### PR TITLE
[codex] Optimize image resize sampling

### DIFF
--- a/src/applications/osgearth_benchmarks/main.cpp
+++ b/src/applications/osgearth_benchmarks/main.cpp
@@ -230,4 +230,50 @@ static void BM_CompressImage_STBDXT(benchmark::State& state)
 }
 BENCHMARK(BM_CompressImage_STBDXT);
 
+static osg::ref_ptr<osg::Image> createResizeBenchmarkImage(unsigned int width, unsigned int height)
+{
+    osg::ref_ptr<osg::Image> image = new osg::Image();
+    image->allocateImage(width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE);
+
+    for (unsigned int t = 0; t < height; ++t)
+    {
+        for (unsigned int s = 0; s < width; ++s)
+        {
+            unsigned char* pixel = image->data(s, t);
+            pixel[0] = static_cast<unsigned char>((s * 3 + t) & 0xff);
+            pixel[1] = static_cast<unsigned char>((s + t * 5) & 0xff);
+            pixel[2] = static_cast<unsigned char>((s * 7 + t * 11) & 0xff);
+            pixel[3] = static_cast<unsigned char>(255 - ((s + t) & 0x7f));
+        }
+    }
+
+    return image;
+}
+
+static void BM_ResizeImage_BilinearRGBA8(benchmark::State& state)
+{
+    osg::ref_ptr<osg::Image> image = createResizeBenchmarkImage(1024, 1024);
+    osg::ref_ptr<osg::Image> output = new osg::Image();
+    output->allocateImage(
+        static_cast<int>(state.range(0)),
+        static_cast<int>(state.range(1)),
+        1,
+        GL_RGBA,
+        GL_UNSIGNED_BYTE);
+
+    for (auto _ : state)
+    {
+        bool result = ImageUtils::resizeImage(
+            image.get(),
+            static_cast<unsigned int>(state.range(0)),
+            static_cast<unsigned int>(state.range(1)),
+            output,
+            0,
+            true);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+}
+BENCHMARK(BM_ResizeImage_BilinearRGBA8)->Args({768, 768})->Unit(benchmark::kMillisecond);
+
 BENCHMARK_MAIN();

--- a/src/applications/osgearth_tests/CMakeLists.txt
+++ b/src/applications/osgearth_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TARGET_SRC
     ExpressionTests.cpp
     GeoExtentTests.cpp
     FeatureTests.cpp
+    ImageUtilsTests.cpp
     PathTests.cpp
     ImageLayerTests.cpp
     SpatialReferenceTests.cpp

--- a/src/applications/osgearth_tests/ImageUtilsTests.cpp
+++ b/src/applications/osgearth_tests/ImageUtilsTests.cpp
@@ -1,0 +1,79 @@
+/* osgEarth
+* Copyright 2025 Pelican Mapping
+* MIT License
+*/
+
+#include <osgEarth/catch.hpp>
+#include <osgEarth/ImageUtils>
+
+using namespace osgEarth;
+using namespace osgEarth::Util;
+
+namespace
+{
+    osg::ref_ptr<osg::Image> createTestImage()
+    {
+        osg::ref_ptr<osg::Image> image = new osg::Image();
+        image->allocateImage(4, 4, 1, GL_RGBA, GL_UNSIGNED_BYTE);
+
+        for (int t = 0; t < image->t(); ++t)
+        {
+            for (int s = 0; s < image->s(); ++s)
+            {
+                unsigned char* pixel = image->data(s, t);
+                pixel[0] = static_cast<unsigned char>(s * 40);
+                pixel[1] = static_cast<unsigned char>(t * 50);
+                pixel[2] = static_cast<unsigned char>(s * 20 + t * 10);
+                pixel[3] = static_cast<unsigned char>(255 - s * 5 - t * 3);
+            }
+        }
+
+        return image;
+    }
+}
+
+TEST_CASE("resizeImage bilinear RGBA8 output is stable")
+{
+    osg::ref_ptr<osg::Image> input = createTestImage();
+    osg::ref_ptr<osg::Image> output;
+
+    REQUIRE(ImageUtils::resizeImage(input.get(), 3, 3, output, 0, true));
+    REQUIRE(output.valid());
+    REQUIRE(output->s() == 3);
+    REQUIRE(output->t() == 3);
+
+    const unsigned char* center = output->data(1, 1);
+    REQUIRE(center[0] == 53);
+    REQUIRE(center[1] == 66);
+    REQUIRE(center[2] == 40);
+    REQUIRE(center[3] == 244);
+
+    const unsigned char* lowerRight = output->data(2, 2);
+    REQUIRE(lowerRight[0] == 106);
+    REQUIRE(lowerRight[1] == 133);
+    REQUIRE(lowerRight[2] == 80);
+    REQUIRE(lowerRight[3] == 233);
+}
+
+TEST_CASE("resizeImage nearest RGBA8 output is stable")
+{
+    osg::ref_ptr<osg::Image> input = createTestImage();
+    osg::ref_ptr<osg::Image> output;
+
+    REQUIRE(ImageUtils::resizeImage(input.get(), 3, 3, output, 0, false));
+    REQUIRE(output.valid());
+    REQUIRE(output->s() == 3);
+    REQUIRE(output->t() == 3);
+
+    const unsigned char* center = output->data(1, 1);
+    REQUIRE(center[0] == 40);
+    REQUIRE(center[1] == 50);
+    REQUIRE(center[2] == 30);
+    REQUIRE(center[3] == 247);
+
+    const unsigned char* lowerRight = output->data(2, 2);
+    REQUIRE(lowerRight[0] == 120);
+    REQUIRE(lowerRight[1] == 150);
+    REQUIRE(lowerRight[2] == 90);
+    REQUIRE(lowerRight[3] == 231);
+}

--- a/src/osgEarth/ImageUtils.cpp
+++ b/src/osgEarth/ImageUtils.cpp
@@ -207,74 +207,99 @@ ImageUtils::resizeImage(const osg::Image* input,
 
         osg::Vec4 color;
 
+        struct ResizeSample
+        {
+            int min;
+            int max;
+            int nearest;
+            double weight0;
+            double weight1;
+        };
+
+        auto makeSample = [](float input_coord, int input_size)
+        {
+            ResizeSample sample;
+
+            if (input_coord >= input_size)
+                input_coord = static_cast<float>(input_size - 1);
+            else if (input_coord < 0.0f)
+                input_coord = 0.0f;
+
+            sample.min = osg::maximum(static_cast<int>(floor(input_coord)), 0);
+            sample.max = osg::maximum(osg::minimum(static_cast<int>(ceil(input_coord)), input_size - 1), 0);
+
+            if (sample.min > sample.max)
+                sample.min = sample.max;
+
+            sample.weight0 = static_cast<double>(sample.max) - static_cast<double>(input_coord);
+            sample.weight1 = static_cast<double>(input_coord) - static_cast<double>(sample.min);
+
+            const int base = static_cast<int>(input_coord);
+            sample.nearest = (input_coord - base) <= (ceil(input_coord) - input_coord) ?
+                base :
+                osg::minimum(1 + base, input_size - 1);
+
+            return sample;
+        };
+
+        std::vector<ResizeSample> rowSamples(out_t);
+        for (unsigned int output_row = 0; output_row < out_t; ++output_row)
+        {
+            const float input_row = ((float)output_row / (float)out_t) * (float)in_t;
+            rowSamples[output_row] = makeSample(input_row, static_cast<int>(in_t));
+        }
+
+        std::vector<ResizeSample> colSamples(out_s);
+        for (unsigned int output_col = 0; output_col < out_s; ++output_col)
+        {
+            const float input_col = ((float)output_col / (float)out_s) * (float)in_s;
+            colSamples[output_col] = makeSample(input_col, static_cast<int>(in_s));
+        }
+
         for( unsigned int output_row=0; output_row < out_t; output_row++ )
         {
-            // get an appropriate input row
-            float output_row_ratio = (float)output_row/(float)out_t;
-            float input_row = output_row_ratio * (float)in_t;
-            if ( input_row >= input->t() ) input_row = in_t-1;
-            else if ( input_row < 0 ) input_row = 0;
+            const ResizeSample& row = rowSamples[output_row];
 
             for( unsigned int output_col = 0; output_col < out_s; output_col++ )
             {
-                float output_col_ratio = (float)output_col/(float)out_s;
-                float input_col =  output_col_ratio * (float)in_s;
-                if ( input_col >= (int)in_s ) input_col = in_s-1;
-                else if ( input_col < 0 ) input_col = 0.0f;
+                const ResizeSample& col = colSamples[output_col];
 
                 for(int layer=0; layer<input->r(); ++layer)
                 {
                     if (bilinear)
                     {
-                        // Do a bilinear interpolation for the image
-                        int rowMin = osg::maximum((int)floor(input_row), 0);
-                        int rowMax = osg::maximum(osg::minimum((int)ceil(input_row), (int)(input->t()-1)), 0);
-                        int colMin = osg::maximum((int)floor(input_col), 0);
-                        int colMax = osg::maximum(osg::minimum((int)ceil(input_col), (int)(input->s()-1)), 0);
+                        osg::Vec4 urColor = read(col.max, row.max, layer);
+                        osg::Vec4 llColor = read(col.min, row.min, layer);
+                        osg::Vec4 ulColor = read(col.min, row.max, layer);
+                        osg::Vec4 lrColor = read(col.max, row.min, layer);
 
-                        if (rowMin > rowMax) rowMin = rowMax;
-                        if (colMin > colMax) colMin = colMax;
-
-                        osg::Vec4 urColor = read(colMax, rowMax, layer);
-                        osg::Vec4 llColor = read(colMin, rowMin, layer);
-                        osg::Vec4 ulColor = read(colMin, rowMax, layer);
-                        osg::Vec4 lrColor = read(colMax, rowMin, layer);
-
-                        if ((colMax == colMin) && (rowMax == rowMin))
+                        if ((col.max == col.min) && (row.max == row.min))
                         {
                             // Exact value
                             color = urColor;
                         }
-                        else if (colMax == colMin)
+                        else if (col.max == col.min)
                         {
                             // Linear interpolate vertically
-                            color = llColor * ((double)rowMax - input_row) + ulColor * (input_row - (double)rowMin);
+                            color = llColor * row.weight0 + ulColor * row.weight1;
                         }
-                        else if (rowMax == rowMin)
+                        else if (row.max == row.min)
                         {
                             // Linear interpolate horizontally
-                            color = llColor * ((double)colMax - input_col) + lrColor * (input_col - (double)colMin);
+                            color = llColor * col.weight0 + lrColor * col.weight1;
                         }
                         else
                         {
                             // Bilinear interpolate
-                            osg::Vec4 r1 = llColor * ((double)colMax - input_col) + lrColor * (input_col - (double)colMin);
-                            osg::Vec4 r2 = ulColor * ((double)colMax - input_col) + urColor * (input_col - (double)colMin);
-                            color = r1 * ((double)rowMax - input_row) + r2 * (input_row - (double)rowMin);
+                            osg::Vec4 r1 = llColor * col.weight0 + lrColor * col.weight1;
+                            osg::Vec4 r2 = ulColor * col.weight0 + urColor * col.weight1;
+                            color = r1 * row.weight0 + r2 * row.weight1;
                         }
                     }
                     else
                     {
                         // nearest neighbor:
-                        int col = (input_col-(int)input_col) <= (ceil(input_col)-input_col) ?
-                            (int)input_col :
-                            osg::minimum( 1+(int)input_col, (int)in_s-1 );
-
-                        int row = (input_row-(int)input_row) <= (ceil(input_row)-input_row) ?
-                            (int)input_row :
-                            osg::minimum( 1+(int)input_row, (int)in_t-1 );
-
-                        read(color, col, row, layer); // read pixel from mip level 0.
+                        read(color, col.nearest, row.nearest, layer); // read pixel from mip level 0.
 
                         // old code
                         //color = read( (int)input_col, (int)input_row, layer ); // read pixel from mip level 0


### PR DESCRIPTION
## Summary

This optimizes `ImageUtils::resizeImage` by precomputing source row/column sampling data once per output row and column. The previous implementation recalculated source coordinates, floors, ceils, clamp bounds, and interpolation weights inside the pixel/layer loop even though those values only depend on the output row or column.

The resize path still uses the existing `PixelReader` and `PixelWriter` abstraction, but it now reuses precomputed nearest-neighbor indices and bilinear interpolation weights while writing pixels.

## Validation

- Configured with `configure.bat`.
- Built with `build.bat`.
- Enabled `OSGEARTH_BUILD_TESTS=ON` in the existing build tree to build `osgearth_tests`.
- From `tests`, after `osgearth_shell.bat`: `osgearth_tests` passed, 325 assertions in 32 test cases.
- Added RGBA8 resize behavior tests for bilinear and nearest-neighbor output.

## Benchmark

Benchmark: `BM_ResizeImage_BilinearRGBA8/768/768`, resizing a 1024x1024 RGBA8 image to 768x768, 5 repetitions.

Before:

- Mean real time: 22.5 ms
- Mean CPU time: 21.9 ms

After:

- Mean real time: 11.8 ms
- Mean CPU time: 11.8 ms

That is about a 48% real-time improvement for the benchmarked bilinear RGBA8 resize case.