### PR TITLE
[codex] Optimize single-point spatial transforms

### DIFF
--- a/src/applications/osgearth_benchmarks/main.cpp
+++ b/src/applications/osgearth_benchmarks/main.cpp
@@ -31,6 +31,22 @@ static void BM_GeoPointTransform(benchmark::State& state)
 }
 BENCHMARK(BM_GeoPointTransform);
 
+static void BM_SpatialReferenceTransformSinglePoint(benchmark::State& state)
+{
+    auto wgs84 = osgEarth::SpatialReference::get("wgs84");
+    auto mercator = osgEarth::SpatialReference::get("spherical-mercator");
+    osg::Vec3d input(-73.935242, 40.730610, 0.0);
+
+    for (auto _ : state)
+    {
+        osg::Vec3d output;
+        bool result = wgs84->transform(input, mercator, output);
+        benchmark::DoNotOptimize(result);
+        benchmark::DoNotOptimize(output);
+    }
+}
+BENCHMARK(BM_SpatialReferenceTransformSinglePoint);
+
 static void BM_GeoExtentContains(benchmark::State& state)
 {
     auto srs = osgEarth::SpatialReference::get("wgs84");

--- a/src/applications/osgearth_tests/SpatialReferenceTests.cpp
+++ b/src/applications/osgearth_tests/SpatialReferenceTests.cpp
@@ -137,6 +137,29 @@ TEST_CASE("SphMercator/WGS84 transform") {
     REQUIRE(vec_eq(temp2, osg::Vec3d(-180, -85, 0)));
 }
 
+TEST_CASE("Single point transforms match batch transforms") {
+    const SpatialReference* wgs84 = SpatialReference::get("wgs84");
+    const SpatialReference* sm = SpatialReference::get("spherical-mercator");
+    const SpatialReference* wgs84_egm96 = SpatialReference::get("wgs84", "egm96");
+    const SpatialReference* ecef = wgs84->getGeocentricSRS();
+
+    auto require_single_matches_batch =
+        [](const SpatialReference* inputSRS, const SpatialReference* outputSRS, const osg::Vec3d& input)
+    {
+        osg::Vec3d single;
+        std::vector<osg::Vec3d> batch(1, input);
+
+        REQUIRE(inputSRS->transform(input, outputSRS, single));
+        REQUIRE(inputSRS->transform(batch, outputSRS));
+        REQUIRE(vec_eq(single, batch[0]));
+    };
+
+    require_single_matches_batch(wgs84, sm, osg::Vec3d(-73.935242, 40.730610, 12.0));
+    require_single_matches_batch(sm, wgs84, osg::Vec3d(-8230420.0, 4972687.0, 12.0));
+    require_single_matches_batch(wgs84, wgs84_egm96, osg::Vec3d(90.0, 0.0, -63.24));
+    require_single_matches_batch(wgs84, ecef, osg::Vec3d(-73.935242, 40.730610, 12.0));
+}
+
 TEST_CASE("Vertical Datum Tests") {
     const SpatialReference* wgs84 = SpatialReference::get("wgs84");
     const SpatialReference* wgs84_egm96 = SpatialReference::get("wgs84", "egm96");

--- a/src/osgEarth/SpatialReference.cpp
+++ b/src/osgEarth/SpatialReference.cpp
@@ -58,6 +58,101 @@ namespace
             minX, minY, 0.0, 1.0);
         return transform;
     }
+
+    bool
+    transformPointZ(
+        osg::Vec3d& point,
+        const SpatialReference* inputSRS,
+        const SpatialReference* outputSRS,
+        bool pointIsLatLong)
+    {
+        const VerticalDatum* inVDatum = inputSRS->getVerticalDatum();
+        const VerticalDatum* outVDatum = outputSRS->getVerticalDatum();
+
+        // same vdatum, no xformation necessary.
+        if (inVDatum == outVDatum)
+            return true;
+
+        UnitsType inUnits = inVDatum ? inVDatum->getUnits() : Units::METERS;
+        UnitsType outUnits = outVDatum ? outVDatum->getUnits() : inUnits;
+
+        osg::Vec3d geoPoint;
+        const osg::Vec3d* latLongPoint = &point;
+
+        if (!inputSRS->isGeographic() && !pointIsLatLong)
+        {
+            geoPoint = point;
+            if (!inputSRS->transform(geoPoint, inputSRS->getGeographicSRS(), geoPoint))
+                return false;
+
+            latLongPoint = &geoPoint;
+        }
+
+        if (inVDatum)
+        {
+            // to HAE:
+            point.z() = inVDatum->msl2hae(latLongPoint->y(), latLongPoint->x(), point.z());
+        }
+
+        // do the units conversion:
+        point.z() = inUnits.convertTo(outUnits, point.z());
+
+        if (outVDatum)
+        {
+            // to MSL:
+            point.z() = outVDatum->hae2msl(latLongPoint->y(), latLongPoint->x(), point.z());
+        }
+
+        return true;
+    }
+
+    bool
+    transformSphericalMercatorXY(
+        osg::Vec3d& point,
+        const SpatialReference* inputSRS,
+        const SpatialReference* outputSRS)
+    {
+        const double radius = 6378137.0;
+
+        if (inputSRS->isGeographic() &&
+            outputSRS->isSphericalMercator() &&
+            inputSRS->isHorizEquivalentTo(outputSRS->getGeographicSRS()))
+        {
+            double lon_deg = inputSRS->getUnits().convertTo(Units::DEGREES, point.x());
+            double lat_deg = inputSRS->getUnits().convertTo(Units::DEGREES, point.y());
+
+            if (lat_deg <= -90.0 || lat_deg >= 90.0)
+                return false;
+
+            point.x() = Units::METERS.convertTo(outputSRS->getUnits(), radius * deg2rad(lon_deg));
+            point.y() = Units::METERS.convertTo(
+                outputSRS->getUnits(),
+                radius * log(tan(osg::PI_4 + deg2rad(lat_deg) * 0.5)));
+
+            return true;
+        }
+
+        if (inputSRS->isSphericalMercator() &&
+            outputSRS->isGeographic() &&
+            outputSRS->isHorizEquivalentTo(inputSRS->getGeographicSRS()))
+        {
+            double x_m = inputSRS->getUnits().convertTo(Units::METERS, point.x());
+            double y_m = inputSRS->getUnits().convertTo(Units::METERS, point.y());
+            double lon_deg = rad2deg(x_m / radius);
+            double lat_deg = rad2deg(2.0 * atan(exp(y_m / radius)) - osg::PI_2);
+
+            point.x() = Units::DEGREES.convertTo(
+                outputSRS->getUnits(),
+                osg::clampBetween(lon_deg, -180.0, 180.0));
+            point.y() = Units::DEGREES.convertTo(
+                outputSRS->getUnits(),
+                osg::clampBetween(lat_deg, -90.0, 90.0));
+
+            return true;
+        }
+
+        return false;
+    }
 }
 
 //------------------------------------------------------------------------
@@ -831,14 +926,88 @@ SpatialReference::transform(const osg::Vec3d&       input,
     if (!valid())
         return false;
 
-    std::vector<osg::Vec3d> v(1, input);
+    output = input;
 
-    if ( transform(v, outputSRS) )
+    // Cube and LTP transforms have custom vector-based pre/post transforms.
+    if (isCube() || isLTP() || outputSRS->isCube() || outputSRS->isLTP())
     {
-        output = v[0];
+        std::vector<osg::Vec3d> v(1, input);
+        if (transform(v, outputSRS))
+        {
+            output = v[0];
+            return true;
+        }
+        return false;
+    }
+
+    // trivial equivalency:
+    if (isEquivalentTo(outputSRS))
+        return true;
+
+    if (isGeocentric() && !outputSRS->isGeocentric())
+    {
+        const SpatialReference* outputGeoSRS = outputSRS->getGeodeticSRS();
+        output = outputGeoSRS->getEllipsoid().geocentricToGeodetic(output);
+        return outputGeoSRS->transform(output, outputSRS, output);
+    }
+
+    else if (!isGeocentric() && outputSRS->isGeocentric())
+    {
+        const SpatialReference* outputGeoSRS = outputSRS->getGeodeticSRS();
+        bool success = transform(output, outputGeoSRS, output);
+        if (success)
+            output = outputGeoSRS->getEllipsoid().geodeticToGeocentric(output);
+        return success;
+    }
+
+    // if the point is starting as geographic, do the Z first to avoid an unnecessary
+    // transformation in the case of differing vdatums.
+    bool z_done = false;
+    if (isGeographic())
+    {
+        z_done = transformPointZ(output, this, outputSRS, true);
+    }
+
+    if (transformSphericalMercatorXY(output, this, outputSRS))
+    {
+        if (!z_done)
+        {
+            z_done = transformPointZ(output, this, outputSRS, outputSRS->isGeographic());
+        }
         return true;
     }
-    return false;
+
+    ThreadLocal& local = getLocal();
+
+    double x = output.x();
+    double y = output.y();
+
+    bool success = transformXYPointArrays(local, &x, &y, 1, outputSRS);
+
+    if (success)
+    {
+        if (isProjected() && outputSRS->isGeographic())
+        {
+            // special case: when going from projected to geographic, clamp the
+            // points to the maximum geographic extent. Sometimes the conversion from
+            // a global/projected SRS (like mercator) will result in *slightly* invalid
+            // geographic points (like long=180.000003), so this addresses that issue.
+            output.x() = osg::clampBetween(x, -180.0, 180.0);
+            output.y() = osg::clampBetween(y, -90.0, 90.0);
+        }
+        else
+        {
+            output.x() = x;
+            output.y() = y;
+        }
+    }
+
+    if (success && !z_done)
+    {
+        z_done = transformPointZ(output, this, outputSRS, outputSRS->isGeographic());
+    }
+
+    return success;
 }
 
 


### PR DESCRIPTION
## Summary

- Add a scalar fast path for `SpatialReference::transform(Vec3d, ...)` so common single-point transforms avoid constructing a one-element vector.
- Add direct spherical Mercator XY formulas for horizontally equivalent geographic <-> spherical Mercator transforms, preserving vertical datum handling and falling back to OGR for other SRS combinations.
- Add a focused benchmark and a regression test that compares single-point results against the existing one-point batch path.

## Performance

Benchmarks were run from `tests` after `osgearth_shell.bat`, using:

```bat
..\install\bin\osgearth_benchmarks --benchmark_filter=GeoPointTransform^|SpatialReferenceTransformSinglePoint --benchmark_repetitions=5 --benchmark_report_aggregates_only=true
```

Before:

- `BM_GeoPointTransform_mean`: 1282 ns wall / 1165 ns CPU
- `BM_SpatialReferenceTransformSinglePoint_mean`: 1840 ns wall / 1613 ns CPU

After:

- `BM_GeoPointTransform_mean`: 125 ns wall / 122 ns CPU
- `BM_SpatialReferenceTransformSinglePoint_mean`: 107 ns wall / 104 ns CPU

## Validation

- `configure.bat`
- `build.bat`
- From `tests`: `..\install\bin\osgearth_tests` after `osgearth_shell.bat` -> all tests passed, 313 assertions in 31 test cases
- Benchmarks above