### PR TITLE
[codex] Use packaged LERC dependency

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,7 @@ jobs:
         sudo apt-get install -y libopenscenegraph-dev
         sudo apt-get install -y libgdal-dev
         sudo apt-get install -y libgeos-dev
+        sudo apt-get install -y liblerc-dev
         sudo apt-get install -y libsqlite3-dev
         sudo apt-get install -y protobuf-compiler libprotobuf-dev
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/third_party/lerc"]
-	path = src/third_party/lerc
-	url = https://github.com/Esri/lerc.git

--- a/cmake/FindLerc.cmake
+++ b/cmake/FindLerc.cmake
@@ -1,0 +1,48 @@
+#
+# FindLerc.cmake
+#
+# Outputs:
+#   Lerc_FOUND (boolean variable)
+#   Lerc::Lerc (imported link library)
+#
+
+find_package(unofficial-lerc CONFIG QUIET)
+
+if(TARGET unofficial::Lerc::Lerc)
+    set(Lerc_LIBRARY unofficial::Lerc::Lerc)
+    set(Lerc_INCLUDE_DIR "provided by unofficial::Lerc::Lerc")
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(Lerc QUIET IMPORTED_TARGET Lerc)
+    endif()
+
+    if(TARGET PkgConfig::Lerc)
+        set(Lerc_LIBRARY PkgConfig::Lerc)
+        set(Lerc_INCLUDE_DIR "provided by PkgConfig::Lerc")
+    else()
+        find_path(Lerc_INCLUDE_DIR NAMES Lerc_c_api.h)
+        find_library(Lerc_LIBRARY NAMES Lerc lerc)
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Lerc DEFAULT_MSG Lerc_LIBRARY Lerc_INCLUDE_DIR)
+
+if(Lerc_FOUND AND NOT TARGET Lerc::Lerc)
+    if(TARGET unofficial::Lerc::Lerc)
+        add_library(Lerc::Lerc INTERFACE IMPORTED)
+        set_property(TARGET Lerc::Lerc PROPERTY
+            INTERFACE_LINK_LIBRARIES unofficial::Lerc::Lerc)
+    elseif(TARGET PkgConfig::Lerc)
+        add_library(Lerc::Lerc INTERFACE IMPORTED)
+        set_property(TARGET Lerc::Lerc PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::Lerc)
+    else()
+        add_library(Lerc::Lerc UNKNOWN IMPORTED)
+        set_target_properties(Lerc::Lerc PROPERTIES
+            IMPORTED_LOCATION "${Lerc_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${Lerc_INCLUDE_DIR}")
+    endif()
+endif()
+

--- a/src/osgEarthDrivers/CMakeLists.txt
+++ b/src/osgEarthDrivers/CMakeLists.txt
@@ -36,7 +36,5 @@ endif()
 
 if(NOT APPLE AND NOT ANDROID)
     add_subdirectory(fastdxt)
-    if(NOT BUILDING_VCPKG_PORT)
-        add_subdirectory(lerc)
-    endif()
+    add_subdirectory(lerc)
 endif()

--- a/src/osgEarthDrivers/lerc/CMakeLists.txt
+++ b/src/osgEarthDrivers/lerc/CMakeLists.txt
@@ -1,15 +1,12 @@
-include_directories(BEFORE ../../third_party/lerc/include )
+find_package(Lerc CONFIG QUIET)
+if(NOT Lerc_FOUND)
+    find_package(Lerc MODULE QUIET)
+endif()
 
-add_osgearth_plugin(
-    TARGET osgdb_lerc
-    SOURCES
-        ReaderWriterLERC.cpp
-        ../../third_party/lerc/src/LercLib/BitMask.cpp
-        ../../third_party/lerc/src/LercLib/BitStuffer2.cpp
-        ../../third_party/lerc/src/LercLib/Huffman.cpp
-        ../../third_party/lerc/src/LercLib/Lerc.cpp
-        ../../third_party/lerc/src/LercLib/Lerc_c_api_impl.cpp
-        ../../third_party/lerc/src/LercLib/Lerc2.cpp
-        ../../third_party/lerc/src/LercLib/RLE.cpp
-        ../../third_party/lerc/src/LercLib/Lerc1Decode/BitStuffer.cpp
-        ../../third_party/lerc/src/LercLib/Lerc1Decode/CntZImage.cpp )
+if(TARGET Lerc::Lerc)
+    message(STATUS "Found LERC")
+    add_osgearth_plugin(
+        TARGET osgdb_lerc
+        SOURCES ReaderWriterLERC.cpp )
+    target_link_libraries(osgdb_lerc PRIVATE Lerc::Lerc)
+endif()

--- a/src/osgEarthDrivers/lerc/ReaderWriterLERC.cpp
+++ b/src/osgEarthDrivers/lerc/ReaderWriterLERC.cpp
@@ -159,7 +159,7 @@ public:
 
         // Decode the image
         unsigned int bandOffset = 0;
-        hr = lerc_decode((const unsigned char*)(data.get()), length, 0, numDims, width, height, numBands, dataType, (void*)output);
+        hr = lerc_decode((const unsigned char*)(data.get()), length, 0, nullptr, numDims, width, height, numBands, dataType, (void*)output);
         if (hr)
         {
             delete[]output;
@@ -334,6 +334,7 @@ public:
         hr = lerc_computeCompressedSize((void*)imageData,    // raw image data, row by row, band by band
             dataType, numDims, width, height, numBands,
             0,
+            nullptr,
             maxZError,           // max coding error per pixel, or precision
             &numBytesNeeded);    // size of outgoing Lerc blob
         if (hr)
@@ -347,7 +348,8 @@ public:
 
         hr = lerc_encode((void*)imageData,    // raw image data, row by row, band by band
             dataType, numDims, width, height, numBands,
-            0,         // can give nullptr if all pixels are valid
+            0,
+            nullptr,             // all pixels are valid
             maxZError,           // max coding error per pixel, or precision
             pLercBlob,           // buffer to write to, function will fail if buffer too small
             numBytesBlob,        // buffer size

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "benchmark",
     "blend2d",
     "draco",
+    "lerc",
     {
       "name": "gdal",
       "default-features": false,


### PR DESCRIPTION
## Summary

- Remove the bundled LERC git submodule and add `lerc` to the vcpkg manifest.
- Add `FindLerc.cmake` so osgEarth consumes packaged LERC through a normalized `Lerc::Lerc` target.
- Support an official `Lerc` CMake config when available, vcpkg's `unofficial-lerc` package, distro `Lerc.pc` pkg-config packages, and a header/library fallback.
- Update the LERC image plugin for the packaged LERC 4.x API.
- Install `liblerc-dev` in the Linux GitHub Actions workflow.

## Validation

- `configure.bat`
- `build.bat`
- `cmd /c "osgearth_shell.bat && cd tests && osgearth_tests"`