### PR TITLE
Linux: Fix virtual overrides hidden warning, by explicitly including virtual overrides with using.

### DIFF
--- a/src/osgEarth/ImageUtils
+++ b/src/osgEarth/ImageUtils
@@ -704,6 +704,8 @@ namespace osgEarth { namespace Util
     class OSGEARTH_EXPORT TextureAndImageVisitor : public osg::NodeVisitor
     {
     public:
+        using osg::NodeVisitor::apply;
+
         TextureAndImageVisitor();
         virtual ~TextureAndImageVisitor() { }
 

--- a/src/osgEarth/MapNodeObserver
+++ b/src/osgEarth/MapNodeObserver
@@ -48,6 +48,8 @@ namespace osgEarth
     class /*header-only*/ MapNodeObserverVisitor : public osg::NodeVisitor
     {
     public:
+        using osg::NodeVisitor::apply;
+
         MapNodeObserverVisitor(osg::NodeVisitor::TraversalMode mode =osg::NodeVisitor::TRAVERSE_ALL_CHILDREN)
             : osg::NodeVisitor( mode ) { }
         

--- a/src/osgEarth/ShaderGenerator
+++ b/src/osgEarth/ShaderGenerator
@@ -71,6 +71,8 @@ namespace osgEarth
     class OSGEARTH_EXPORT ShaderGenerator : public osg::NodeVisitor
     {
     public:
+        using osg::NodeVisitor::apply;
+
         /** Constructs a new shader generator */
         ShaderGenerator();
 


### PR DESCRIPTION
This fixes several GCC warnings that spam when building against an installed osgEarth.