### PR TITLE
Lerc: Support static and debug configurations.

### DIFF
--- a/cmake/FindLerc.cmake
+++ b/cmake/FindLerc.cmake
@@ -22,7 +22,13 @@ else()
         set(Lerc_INCLUDE_DIR "provided by PkgConfig::Lerc")
     else()
         find_path(Lerc_INCLUDE_DIR NAMES Lerc_c_api.h)
-        find_library(Lerc_LIBRARY NAMES Lerc lerc)
+        # Search for both Release and Debug libraries separately
+        find_library(Lerc_LIBRARY_RELEASE NAMES Lerc lerc)
+        find_library(Lerc_LIBRARY_DEBUG NAMES Lercd lercd Lerc_d lerc_d)
+
+        # Automatically handles setting Lerc_LIBRARY based on what was found
+        include(SelectLibraryConfigurations)
+        select_library_configurations(Lerc)
     endif()
 endif()
 
@@ -40,9 +46,27 @@ if(Lerc_FOUND AND NOT TARGET Lerc::Lerc)
             INTERFACE_LINK_LIBRARIES PkgConfig::Lerc)
     else()
         add_library(Lerc::Lerc UNKNOWN IMPORTED)
-        set_target_properties(Lerc::Lerc PROPERTIES
-            IMPORTED_LOCATION "${Lerc_LIBRARY}"
-            INTERFACE_INCLUDE_DIRECTORIES "${Lerc_INCLUDE_DIR}")
+        set_target_properties(Lerc::Lerc PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Lerc_INCLUDE_DIR}")
+
+        # Explicitly map the Release library if it was found
+        if(Lerc_LIBRARY_RELEASE)
+            set_property(TARGET Lerc::Lerc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(Lerc::Lerc PROPERTIES IMPORTED_LOCATION_RELEASE "${Lerc_LIBRARY_RELEASE}")
+        endif()
+
+        # Explicitly map the Debug library if it was found
+        if(Lerc_LIBRARY_DEBUG)
+            set_property(TARGET Lerc::Lerc APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(Lerc::Lerc PROPERTIES IMPORTED_LOCATION_DEBUG "${Lerc_LIBRARY_DEBUG}")
+        endif()
+
+        # Provide a fallback for single-config generators or if only one lib exists
+        if(Lerc_LIBRARY)
+            set_target_properties(Lerc::Lerc PROPERTIES IMPORTED_LOCATION "${Lerc_LIBRARY}")
+        endif()
+
+        if(LERC_STATIC)
+            set_property(TARGET Lerc::Lerc APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS LERC_STATIC)
+        endif()
     endif()
 endif()
-


### PR DESCRIPTION
Intended to support custom third party builds of Lerc, from the Lerc CMake configuration. Includes support for a static Lerc with the CMake flag LERC_STATIC, and explicit release (`/MD`) and debug (`/MDd') libraries for use with MSVC.