### PR TITLE
[codex] Optimize TileKey string formatting

### DIFF
--- a/src/applications/osgearth_benchmarks/main.cpp
+++ b/src/applications/osgearth_benchmarks/main.cpp
@@ -11,6 +11,7 @@
 #include <osgEarth/Map>
 #include <osgEarth/SpatialReference>
 #include <osgEarth/StringUtils>
+#include <osgEarth/TileKey>
 #include <osgEarth/Cache>
 #include <osgEarth/ImageUtils>
 #include <osgDB/ReadFile>
@@ -166,6 +167,42 @@ static void BM_ElevationPoolSampleMapCoordsFixedResolution(benchmark::State& sta
     }
 }
 BENCHMARK(BM_ElevationPoolSampleMapCoordsFixedResolution)->Arg(4096);
+
+
+static void BM_TileKeyString(benchmark::State& state)
+{
+    osg::ref_ptr<const Profile> profile = Profile::create(Profile::GLOBAL_GEODETIC);
+
+    std::vector<TileKey> keys;
+    keys.reserve(state.range(0));
+    for (int i = 0; i < state.range(0); ++i)
+    {
+        const unsigned lod = 8u + static_cast<unsigned>(i % 16);
+        keys.emplace_back(
+            lod,
+            12345u + static_cast<unsigned>(i * 37u),
+            67890u + static_cast<unsigned>(i * 53u),
+            profile.get());
+    }
+
+    if (TileKey(17u, 123456u, 654321u, profile.get()).str() != "17/123456/654321")
+    {
+        state.SkipWithError("TileKey string formatting changed unexpectedly");
+        return;
+    }
+
+    for (auto _ : state)
+    {
+        for (const auto& key : keys)
+        {
+            std::string formatted = key.str();
+            benchmark::DoNotOptimize(formatted);
+        }
+    }
+
+    state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(keys.size()));
+}
+BENCHMARK(BM_TileKeyString)->Arg(4096);
 
 
 

--- a/src/applications/osgearth_tests/CMakeLists.txt
+++ b/src/applications/osgearth_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TARGET_SRC
     PathTests.cpp
     ImageLayerTests.cpp
     SpatialReferenceTests.cpp
+    TileKeyTests.cpp
     ThreadingTests.cpp)
 
 add_osgearth_app(

--- a/src/applications/osgearth_tests/TileKeyTests.cpp
+++ b/src/applications/osgearth_tests/TileKeyTests.cpp
@@ -1,0 +1,37 @@
+/* osgEarth
+* Copyright 2025 Pelican Mapping
+* MIT License
+*/
+
+#include <osgEarth/catch.hpp>
+
+#include <osgEarth/TileKey>
+#include <limits>
+
+using namespace osgEarth;
+
+TEST_CASE("TileKey string formatting")
+{
+    osg::ref_ptr<const Profile> profile = Profile::create(Profile::GLOBAL_GEODETIC);
+
+    SECTION("valid tile keys")
+    {
+        REQUIRE(TileKey(0u, 0u, 0u, profile.get()).str() == "0/0/0");
+        REQUIRE(TileKey(17u, 123456u, 654321u, profile.get()).str() == "17/123456/654321");
+    }
+
+    SECTION("max unsigned values")
+    {
+        const unsigned int maxValue = std::numeric_limits<unsigned int>::max();
+        const std::string expected = std::to_string(maxValue) + "/" +
+            std::to_string(maxValue) + "/" +
+            std::to_string(maxValue);
+
+        REQUIRE(TileKey(maxValue, maxValue, maxValue, profile.get()).str() == expected);
+    }
+
+    SECTION("invalid tile key")
+    {
+        REQUIRE(TileKey::INVALID.str() == "invalid");
+    }
+}

--- a/src/osgEarth/TileKey.cpp
+++ b/src/osgEarth/TileKey.cpp
@@ -5,8 +5,21 @@
 
 #include <osgEarth/TileKey>
 #include <osgEarth/Math>
+#include <charconv>
+#include <limits>
 
 using namespace osgEarth;
+
+namespace
+{
+    constexpr std::size_t MAX_UNSIGNED_DIGITS = std::numeric_limits<unsigned int>::digits10 + 1u;
+    constexpr std::size_t MAX_TILEKEY_STRING_SIZE = 3u * MAX_UNSIGNED_DIGITS + 2u;
+
+    char* appendUnsigned(char* out, char* end, unsigned int value)
+    {
+        return std::to_chars(out, end, value).ptr;
+    }
+}
 
 //------------------------------------------------------------------------
 
@@ -80,9 +93,17 @@ TileKey::str() const
 {
     if (valid())
     {
-        char buf[255];
-        sprintf(buf, "%u/%u/%u", _lod, _x, _y);
-        return std::string(buf);
+        char buf[MAX_TILEKEY_STRING_SIZE];
+        char* out = buf;
+        char* end = buf + sizeof(buf);
+
+        out = appendUnsigned(out, end, _lod);
+        *out++ = '/';
+        out = appendUnsigned(out, end, _x);
+        *out++ = '/';
+        out = appendUnsigned(out, end, _y);
+
+        return std::string(buf, out);
     }
     else return "invalid";
 }


### PR DESCRIPTION
## Summary

- Replace `TileKey::str()`'s `sprintf` formatting with bounded integer `std::to_chars` formatting.
- Add `BM_TileKeyString` to cover this previously unbenchmarked tile-key string path.
- Add Catch tests for valid, max-value, and invalid tile-key string output.

## Performance

Command run from `tests` after `build.bat`:

```bat
cmd /c "pushd .. && call osgearth_shell.bat && popd && osgearth_benchmarks --benchmark_filter=BM_TileKeyString --benchmark_repetitions=10 --benchmark_report_aggregates_only=true"
```

Baseline (`sprintf`):

```text
BM_TileKeyString/4096_mean 291239 ns, items_per_second=14.0649M/s
```

After (`std::to_chars`):

```text
BM_TileKeyString/4096_mean 130463 ns, items_per_second=31.37M/s
```

That is about a 55% reduction in mean time for this benchmark and about 2.23x throughput.

## Validation

- `configure.bat`
- `build.bat`
- `cmd /c "pushd .. && call osgearth_shell.bat && popd && osgearth_tests"`
  - all tests passed: 329 assertions in 33 test cases
- `cmd /c "pushd .. && call osgearth_shell.bat && popd && osgearth_benchmarks --benchmark_filter=BM_TileKeyString --benchmark_repetitions=10 --benchmark_report_aggregates_only=true"`