### PR TITLE
[codex] Optimize string replacement

### DIFF
--- a/src/applications/osgearth_benchmarks/main.cpp
+++ b/src/applications/osgearth_benchmarks/main.cpp
@@ -73,6 +73,46 @@ namespace
 
         return map;
     }
+
+    std::string createStringReplaceInBenchmarkInput(unsigned markerCount, const std::string& marker)
+    {
+        std::string input;
+        input.reserve(markerCount * 96u);
+
+        for (unsigned i = 0; i < markerCount; ++i)
+        {
+            input += "vec4 sample_";
+            input += std::to_string(i);
+            input += " = texture(";
+            input += marker;
+            input += ", uv) * ";
+            input += marker;
+            input += "_scale;\n";
+        }
+
+        return input;
+    }
+
+    std::string createStringReplaceInBenchmarkExpected(
+        unsigned markerCount,
+        const std::string& replacement)
+    {
+        std::string expected;
+        expected.reserve(markerCount * 128u);
+
+        for (unsigned i = 0; i < markerCount; ++i)
+        {
+            expected += "vec4 sample_";
+            expected += std::to_string(i);
+            expected += " = texture(";
+            expected += replacement;
+            expected += ", uv) * ";
+            expected += replacement;
+            expected += "_scale;\n";
+        }
+
+        return expected;
+    }
 }
 
 static void BM_GeoPointTransform(benchmark::State& state)
@@ -166,6 +206,35 @@ static void BM_ElevationPoolSampleMapCoordsFixedResolution(benchmark::State& sta
     }
 }
 BENCHMARK(BM_ElevationPoolSampleMapCoordsFixedResolution)->Arg(4096);
+
+
+static void BM_StringReplaceInExpanding(benchmark::State& state)
+{
+    const std::string marker = "$OE_TEX";
+    const std::string replacement = "oe_layer_texture_unit_0123456789";
+    const unsigned markerCount = static_cast<unsigned>(state.range(0));
+    const std::string input = createStringReplaceInBenchmarkInput(markerCount, marker);
+
+    std::string sanity = input;
+    Strings::replaceIn(sanity, marker, replacement);
+
+    if (sanity != createStringReplaceInBenchmarkExpected(markerCount, replacement))
+    {
+        state.SkipWithError("Strings::replaceIn produced an unexpected replacement result");
+        return;
+    }
+
+    for (auto _ : state)
+    {
+        std::string working = input;
+        Strings::replaceIn(working, marker, replacement);
+        benchmark::DoNotOptimize(working);
+        benchmark::ClobberMemory();
+    }
+
+    state.SetItemsProcessed(state.iterations() * static_cast<int64_t>(markerCount * 2u));
+}
+BENCHMARK(BM_StringReplaceInExpanding)->Arg(2048);
 
 
 

--- a/src/applications/osgearth_tests/CMakeLists.txt
+++ b/src/applications/osgearth_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TARGET_SRC
     ImageUtilsTests.cpp
     PathTests.cpp
     ImageLayerTests.cpp
+    StringUtilsTests.cpp
     SpatialReferenceTests.cpp
     ThreadingTests.cpp)
 

--- a/src/applications/osgearth_tests/StringUtilsTests.cpp
+++ b/src/applications/osgearth_tests/StringUtilsTests.cpp
@@ -1,0 +1,62 @@
+/* osgEarth
+* Copyright 2025 Pelican Mapping
+* MIT License
+*/
+
+#include <osgEarth/catch.hpp>
+#include <osgEarth/StringUtils>
+
+using namespace osgEarth;
+using namespace osgEarth::Util;
+
+TEST_CASE("replaceIn preserves replacement semantics")
+{
+    SECTION("Empty pattern is a no-op")
+    {
+        std::string value = "abc";
+        REQUIRE(&Strings::replaceIn(value, "", "x") == &value);
+        REQUIRE(value == "abc");
+    }
+
+    SECTION("No match is a no-op")
+    {
+        std::string value = "abc";
+        REQUIRE(&Strings::replaceIn(value, "z", "x") == &value);
+        REQUIRE(value == "abc");
+    }
+
+    SECTION("Single match expands")
+    {
+        std::string value = "a ${x} b";
+        REQUIRE(&Strings::replaceIn(value, "${x}", "expanded") == &value);
+        REQUIRE(value == "a expanded b");
+    }
+
+    SECTION("Multiple matches expand")
+    {
+        std::string value = "${x}/${x}/${x}";
+        REQUIRE(&Strings::replaceIn(value, "${x}", "expanded") == &value);
+        REQUIRE(value == "expanded/expanded/expanded");
+    }
+
+    SECTION("Multiple matches shrink")
+    {
+        std::string value = "prefix--middle--suffix";
+        REQUIRE(&Strings::replaceIn(value, "--", "-") == &value);
+        REQUIRE(value == "prefix-middle-suffix");
+    }
+
+    SECTION("Same-size replacements still replace all matches")
+    {
+        std::string value = "abc abc abc";
+        REQUIRE(&Strings::replaceIn(value, "abc", "xyz") == &value);
+        REQUIRE(value == "xyz xyz xyz");
+    }
+
+    SECTION("Matches remain non-overlapping")
+    {
+        std::string value = "aaa";
+        REQUIRE(&Strings::replaceIn(value, "aa", "a") == &value);
+        REQUIRE(value == "aa");
+    }
+}

--- a/src/osgEarth/StringUtils.cpp
+++ b/src/osgEarth/StringUtils.cpp
@@ -464,14 +464,51 @@ std::string&
 osgEarth::Util::replaceIn(std::string& s, const std::string& sub, const std::string& other)
 {
     if (sub.empty()) return s;
-    size_t b = 0;
-    for (; ; )
+
+    size_t first = s.find(sub);
+    if (first == std::string::npos) return s;
+
+    if (sub.size() == other.size())
     {
-        b = s.find(sub, b);
-        if (b == s.npos) break;
-        s.replace(b, sub.size(), other);
-        b += other.size();
+        for (size_t b = first; b != std::string::npos; b = s.find(sub, b + other.size()))
+        {
+            s.replace(b, sub.size(), other);
+        }
+
+        return s;
     }
+
+    size_t count = 1;
+    size_t second = s.find(sub, first + sub.size());
+    if (second == std::string::npos)
+    {
+        s.replace(first, sub.size(), other);
+        return s;
+    }
+
+    for (size_t b = second; b != std::string::npos; b = s.find(sub, b + sub.size()))
+    {
+        ++count;
+    }
+
+    const size_t finalSize =
+        other.size() > sub.size() ?
+        s.size() + count * (other.size() - sub.size()) :
+        s.size() - count * (sub.size() - other.size());
+
+    std::string output;
+    output.reserve(finalSize);
+
+    size_t tail = 0;
+    for (size_t b = first; b != std::string::npos; b = s.find(sub, tail))
+    {
+        output.append(s, tail, b - tail);
+        output.append(other);
+        tail = b + sub.size();
+    }
+    output.append(s, tail, std::string::npos);
+
+    s.swap(output);
     return s;
 }
 


### PR DESCRIPTION
## Summary

Optimizes `osgEarth::Util::replaceIn` for multi-match replacements that change string length. The old path repeatedly called `std::string::replace`, which forces repeated shifting/reallocation when expanding shader- or URL-template strings. The new path keeps cheap no-match, single-match, and same-size cases, and builds a pre-sized output string for multiple length-changing replacements.

## Real code paths

This is useful outside the benchmark in a few existing osgEarth paths:

- `src/osgEarth/ShaderUtils.cpp:215-218` rewrites legacy GLSL matrix symbols such as `gl_ModelViewMatrix` to `osg_ModelViewMatrix` through `GLSLChunker::replace`; `src/osgEarth/GLSLChunker.cpp:257-264` applies `replaceIn` to chunk text and token lists. These are length-changing replacements that can appear multiple times in shader chunks.
- `src/osgEarth/ShaderLoader.cpp:407-410` applies every `ShaderPackage::replace` entry to loaded shader source. Real producers include decal compute shader binding replacement in `src/osgEarth/Decals.cpp:379-387` and terrain shader package replacements in `src/osgEarthDrivers/engine_mp/MPTerrainEngineNode.cpp:954-957`.
- `src/osgEarth/VirtualProgram.cpp:491-497` applies accumulated vertex attribute aliases across shader source before installing it back into the shader.
- Terrain color-filter shader assembly uses `replaceIn` to inject generated filter declarations/bodies in `src/osgEarthDrivers/engine_mp/MPTerrainEngineNode.cpp:1035-1042` and `src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp:1501-1508`.
- Tile URL creation paths use `replaceIn` for template expansion in `src/osgEarth/XYZ.cpp:64-85`, `src/osgEarth/XYZFeatureSource.cpp:334-354`, and `src/osgEarth/XYZModelLayer.cpp:152-164`. Those calls are shorter strings than the benchmark, but they happen along tile request paths.

## Validation

- `build.bat`
- From `tests` after `osgearth_shell.bat`: `osgearth_tests`
  - Passed: 339 assertions in 33 test cases
- From `tests` after `osgearth_shell.bat`: `osgearth_benchmarks --benchmark_filter=BM_StringReplaceInExpanding --benchmark_min_time=0.2s --benchmark_repetitions=5 --benchmark_report_aggregates_only=true`

## Benchmark

`BM_StringReplaceInExpanding/2048` mean wall time:

- Before: 2,566,346 ns
- After: 93,237 ns
- Improvement: ~27.5x faster

The benchmark includes a behavior sanity check for the replacement output, and `StringUtilsTests.cpp` covers empty-pattern, no-match, single-match, expanding, shrinking, same-size, and non-overlapping replacement semantics.