### PR TITLE
[codex] Speed up ImageLayer reprojection assembly

### DIFF
--- a/src/applications/osgearth_benchmarks/main.cpp
+++ b/src/applications/osgearth_benchmarks/main.cpp
@@ -8,6 +8,7 @@
 #include <osgEarth/ElevationPool>
 #include <osgEarth/GeoData>
 #include <osgEarth/HeightFieldUtils>
+#include <osgEarth/ImageLayer>
 #include <osgEarth/Map>
 #include <osgEarth/SpatialReference>
 #include <osgEarth/StringUtils>
@@ -129,6 +130,62 @@ namespace
         static MBTilesReadBenchmarkData data;
         return data;
     }
+
+    osg::ref_ptr<osg::Image> createReprojectionBenchmarkImage(unsigned int width, unsigned int height)
+    {
+        osg::ref_ptr<osg::Image> image = new osg::Image();
+        image->allocateImage(width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE);
+
+        for (unsigned int t = 0; t < height; ++t)
+        {
+            for (unsigned int s = 0; s < width; ++s)
+            {
+                unsigned char* pixel = image->data(s, t);
+                pixel[0] = static_cast<unsigned char>((s * 3 + t) & 0xff);
+                pixel[1] = static_cast<unsigned char>((s + t * 5) & 0xff);
+                pixel[2] = static_cast<unsigned char>((s * 7 + t * 11) & 0xff);
+                pixel[3] = 255u;
+            }
+        }
+
+        return image;
+    }
+
+    class ReprojectionBenchmarkImageLayer : public ImageLayer
+    {
+    public:
+        META_LayerNoOptions(osgEarth, ReprojectionBenchmarkImageLayer, ImageLayer, reprojection_benchmark_image);
+
+        void init() override
+        {
+            ImageLayer::init();
+            setProfile(Profile::create(Profile::GLOBAL_GEODETIC));
+            setTileSize(256u);
+            setMaxDataLevel(18u);
+            setCachePolicy(CachePolicy::NO_CACHE);
+        }
+
+        Status openImplementation() override
+        {
+            Status parent = ImageLayer::openImplementation();
+            if (parent.isError())
+                return parent;
+
+            _image = createReprojectionBenchmarkImage(256u, 256u);
+            return parent;
+        }
+
+        GeoImage createImageImplementation(const TileKey& key, ProgressCallback*) const override
+        {
+            return GeoImage(_image.get(), key.getExtent());
+        }
+
+    protected:
+        virtual ~ReprojectionBenchmarkImageLayer() { }
+
+    private:
+        osg::ref_ptr<osg::Image> _image;
+    };
 }
 
 static void BM_GeoPointTransform(benchmark::State& state)
@@ -245,6 +302,41 @@ static void BM_MBTilesImageRead_PNG(benchmark::State& state)
     }
 }
 BENCHMARK(BM_MBTilesImageRead_PNG)->ThreadRange(1, 8)->UseRealTime()->Unit(benchmark::kMicrosecond);
+
+static void BM_ImageLayerAssembleImage_Reproject(benchmark::State& state)
+{
+    osg::ref_ptr<ReprojectionBenchmarkImageLayer> layer = new ReprojectionBenchmarkImageLayer();
+    Status status = layer->open();
+    if (status.isError())
+    {
+        state.SkipWithError(status.toString().c_str());
+        return;
+    }
+
+    osg::ref_ptr<const Profile> outputProfile = Profile::create(Profile::GLOBAL_MERCATOR);
+    TileKey key(4u, 8u, 5u, outputProfile.get());
+
+    GeoImage warmup = layer->createImage(key, nullptr);
+    if (!warmup.valid())
+    {
+        state.SkipWithError("ImageLayer reprojection benchmark failed to create warmup tile");
+        return;
+    }
+
+    for (auto _ : state)
+    {
+        GeoImage image = layer->createImage(key, nullptr);
+        if (!image.valid())
+        {
+            state.SkipWithError("ImageLayer reprojection benchmark failed to create tile");
+            return;
+        }
+
+        benchmark::DoNotOptimize(image.getImage());
+        benchmark::ClobberMemory();
+    }
+}
+BENCHMARK(BM_ImageLayerAssembleImage_Reproject)->Unit(benchmark::kMillisecond);
 
 
 

--- a/src/applications/osgearth_tests/ImageLayerTests.cpp
+++ b/src/applications/osgearth_tests/ImageLayerTests.cpp
@@ -6,10 +6,173 @@
 #include <osgEarth/catch.hpp>
 
 #include <osgEarth/ImageLayer>
+#include <osgEarth/ImageUtils>
+#include <osgEarth/Math>
 #include <osgEarth/Registry>
 #include <osgEarth/GDAL>
 
+#include <algorithm>
+#include <cmath>
+
 using namespace osgEarth;
+
+namespace
+{
+    osg::ref_ptr<osg::Image> createReprojectionTestImage(unsigned int width, unsigned int height)
+    {
+        osg::ref_ptr<osg::Image> image = new osg::Image();
+        image->allocateImage(width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE);
+
+        for (unsigned int t = 0; t < height; ++t)
+        {
+            for (unsigned int s = 0; s < width; ++s)
+            {
+                unsigned char* pixel = image->data(s, t);
+                pixel[0] = static_cast<unsigned char>((s * 3 + t) & 0xff);
+                pixel[1] = static_cast<unsigned char>((s + t * 5) & 0xff);
+                pixel[2] = static_cast<unsigned char>((s * 7 + t * 11) & 0xff);
+                pixel[3] = 255u;
+            }
+        }
+
+        return image;
+    }
+
+    class ReprojectionTestImageLayer : public ImageLayer
+    {
+    public:
+        META_LayerNoOptions(osgEarth, ReprojectionTestImageLayer, ImageLayer, reprojection_test_image);
+
+        void init() override
+        {
+            ImageLayer::init();
+            setProfile(Profile::create(Profile::GLOBAL_GEODETIC));
+            setTileSize(64u);
+            setMaxDataLevel(18u);
+            setCachePolicy(CachePolicy::NO_CACHE);
+        }
+
+        Status openImplementation() override
+        {
+            Status parent = ImageLayer::openImplementation();
+            if (parent.isError())
+                return parent;
+
+            _image = createReprojectionTestImage(getTileSize(), getTileSize());
+            return parent;
+        }
+
+        GeoImage createImageImplementation(const TileKey& key, ProgressCallback*) const override
+        {
+            return GeoImage(_image.get(), key.getExtent());
+        }
+
+    protected:
+        virtual ~ReprojectionTestImageLayer() { }
+
+    private:
+        osg::ref_ptr<osg::Image> _image;
+    };
+
+    GeoImage createExactAssembledImage(ReprojectionTestImageLayer* layer, const TileKey& key)
+    {
+        unsigned targetLOD = layer->getProfile()->getEquivalentLOD(key.getProfile(), key.getLOD());
+
+        std::vector<TileKey> intersectingKeys;
+        layer->getProfile()->getIntersectingTiles(key, intersectingKeys);
+
+        using KeyedImage = std::pair<TileKey, GeoImage>;
+        std::vector<KeyedImage> sources;
+
+        for (auto& intersectingKey : intersectingKeys)
+        {
+            GeoImage subTile = layer->createImageImplementation(intersectingKey, nullptr);
+            if (subTile.valid() && intersectingKey.getLOD() == targetLOD)
+            {
+                sources.emplace_back(intersectingKey, subTile);
+            }
+        }
+
+        REQUIRE(!sources.empty());
+
+        std::sort(
+            sources.begin(), sources.end(),
+            [](const KeyedImage& lhs, const KeyedImage& rhs) {
+                return lhs.first.getLOD() > rhs.first.getLOD();
+            });
+
+        auto* proto = sources.front().second.getImage();
+        unsigned cols = layer->getTileSize();
+        unsigned rows = layer->getTileSize();
+        unsigned layers = proto->r();
+
+        osg::ref_ptr<osg::Image> mosaic = new osg::Image();
+        mosaic->allocateImage(cols, rows, layers, proto->getPixelFormat(), proto->getDataType());
+        mosaic->setInternalTextureFormat(proto->getInternalTextureFormat());
+
+        std::vector<osg::Vec3d> points(cols * rows);
+
+        double minx, miny, maxx, maxy;
+        key.getExtent().getBounds(minx, miny, maxx, maxy);
+        double dx = (maxx - minx) / static_cast<double>(cols);
+        double dy = (maxy - miny) / static_cast<double>(rows);
+
+        for (unsigned t = 0; t < rows; ++t)
+        {
+            double y = miny + (0.5 * dy) + (dy * static_cast<double>(t));
+            for (unsigned s = 0; s < cols; ++s)
+            {
+                double x = minx + (0.5 * dx) + (dx * static_cast<double>(s));
+                points[t * cols + s] = { x, y, 0.0 };
+            }
+        }
+
+        auto* key_srs = key.getExtent().getSRS();
+        auto* source_srs = sources.front().second.getSRS();
+
+        Bounds sourceBounds;
+        source_srs->getBounds(sourceBounds);
+
+        if (source_srs && key_srs)
+        {
+            key_srs->transform(points, source_srs);
+
+            if (sourceBounds.valid())
+            {
+                for (auto& point : points)
+                {
+                    point.x() = clamp(point.x(), sourceBounds.xMin(), sourceBounds.xMax());
+                    point.y() = clamp(point.y(), sourceBounds.yMin(), sourceBounds.yMax());
+                }
+            }
+        }
+
+        std::vector<GeoImagePixelReader> readers;
+        for (auto& source : sources)
+        {
+            readers.emplace_back(source.second);
+            readers.back().setBilinear(!layer->isCoverage());
+        }
+
+        ImageUtils::PixelWriter write_mosaic(mosaic.get());
+        osg::Vec4f pixel;
+
+        write_mosaic.forEachPixel([&](auto& iter)
+        {
+            unsigned i = iter.t() * cols + iter.s();
+            pixel.set(0, 0, 0, 0);
+
+            for (unsigned k = 0; k < sources.size() && pixel.a() == 0.0f; ++k)
+            {
+                readers[k].readCoordWithoutClamping(pixel, points[i].x(), points[i].y(), iter.r());
+            }
+
+            write_mosaic(pixel, iter);
+        });
+
+        return GeoImage(mosaic.get(), key.getExtent());
+    }
+}
 
 TEST_CASE( "ImageLayers can be created" )
 {
@@ -50,4 +213,62 @@ TEST_CASE("Attribution works")
 
     REQUIRE(status.isOK());
     REQUIRE(layer->getAttribution() == attribution);
+}
+
+static void checkImageLayerReprojectionAssemblyMatchesExact(bool coverage)
+{
+    osg::ref_ptr<ReprojectionTestImageLayer> layer = new ReprojectionTestImageLayer();
+    layer->setCoverage(coverage);
+    Status status = layer->open();
+    REQUIRE(status.isOK());
+
+    osg::ref_ptr<const Profile> outputProfile = Profile::create(Profile::GLOBAL_MERCATOR);
+    TileKey key(5u, 16u, 11u, outputProfile.get());
+
+    GeoImage actual = layer->createImage(key, nullptr);
+    GeoImage expected = createExactAssembledImage(layer.get(), key);
+
+    REQUIRE(actual.valid());
+    REQUIRE(expected.valid());
+    REQUIRE(actual.getImage()->s() == expected.getImage()->s());
+    REQUIRE(actual.getImage()->t() == expected.getImage()->t());
+
+    ImageUtils::PixelReader readActual(actual.getImage());
+    ImageUtils::PixelReader readExpected(expected.getImage());
+
+    osg::Vec4f actualPixel;
+    osg::Vec4f expectedPixel;
+    const float tolerance = coverage ? 0.0f : 3.0f / 255.0f;
+
+    for (int t = 0; t < actual.getImage()->t(); ++t)
+    {
+        for (int s = 0; s < actual.getImage()->s(); ++s)
+        {
+            readActual(actualPixel, s, t);
+            readExpected(expectedPixel, s, t);
+
+            for (int c = 0; c < 4; ++c)
+            {
+                CAPTURE(s);
+                CAPTURE(t);
+                CAPTURE(c);
+                CAPTURE(actualPixel[c]);
+                CAPTURE(expectedPixel[c]);
+                REQUIRE(std::abs(actualPixel[c] - expectedPixel[c]) <= tolerance);
+            }
+        }
+    }
+}
+
+TEST_CASE("ImageLayer reprojection assembly matches exact sampling")
+{
+    SECTION("imagery")
+    {
+        checkImageLayerReprojectionAssemblyMatchesExact(false);
+    }
+
+    SECTION("coverage")
+    {
+        checkImageLayerReprojectionAssemblyMatchesExact(true);
+    }
 }

--- a/src/osgEarth/ImageLayer.cpp
+++ b/src/osgEarth/ImageLayer.cpp
@@ -22,6 +22,293 @@ using namespace osgEarth;
 //#undef  OE_DEBUG
 //#define OE_DEBUG OE_INFO
 
+namespace
+{
+    constexpr unsigned ASSEMBLE_IMAGE_REPROJECTION_MESH_SIZE = 4u;
+
+    void buildPixelCenterPoints(
+        const GeoExtent& extent,
+        unsigned cols,
+        unsigned rows,
+        std::vector<osg::Vec3d>& points)
+    {
+        points.resize(cols * rows);
+
+        double minx, miny, maxx, maxy;
+        extent.getBounds(minx, miny, maxx, maxy);
+        double dx = (maxx - minx) / static_cast<double>(cols);
+        double dy = (maxy - miny) / static_cast<double>(rows);
+
+        for (unsigned t = 0; t < rows; ++t)
+        {
+            double y = miny + (0.5 * dy) + (dy * static_cast<double>(t));
+            for (unsigned s = 0; s < cols; ++s)
+            {
+                double x = minx + (0.5 * dx) + (dx * static_cast<double>(s));
+                points[t * cols + s] = { x, y, 0.0 };
+            }
+        }
+    }
+
+    void clampPointToBounds(osg::Vec3d& point, const Bounds& bounds)
+    {
+        point.x() = clamp(point.x(), bounds.xMin(), bounds.xMax());
+        point.y() = clamp(point.y(), bounds.yMin(), bounds.yMax());
+    }
+
+    void clampPointsToBounds(std::vector<osg::Vec3d>& points, const Bounds& bounds)
+    {
+        if (bounds.valid())
+        {
+            for (auto& point : points)
+            {
+                clampPointToBounds(point, bounds);
+            }
+        }
+    }
+
+    void buildMeshAxis(unsigned size, unsigned step, std::vector<unsigned>& axis)
+    {
+        axis.clear();
+        if (size == 0u)
+            return;
+
+        axis.reserve((size + step - 1u) / step + 1u);
+        for (unsigned i = 0u; i < size; i += step)
+        {
+            axis.push_back(i);
+        }
+
+        if (axis.back() != size - 1u)
+        {
+            axis.push_back(size - 1u);
+        }
+    }
+
+    void buildExactReprojectionPoints(
+        const GeoExtent& extent,
+        unsigned cols,
+        unsigned rows,
+        const SpatialReference* source_srs,
+        const Bounds& sourceBounds,
+        std::vector<osg::Vec3d>& points)
+    {
+        buildPixelCenterPoints(extent, cols, rows, points);
+
+        auto* key_srs = extent.getSRS();
+        if (source_srs && key_srs)
+        {
+            key_srs->transform(points, source_srs);
+            clampPointsToBounds(points, sourceBounds);
+        }
+    }
+
+    bool canUseRowInterpolatedReprojection(
+        const SpatialReference* key_srs,
+        const SpatialReference* source_srs)
+    {
+        if (!key_srs || !source_srs || key_srs->isEquivalentTo(source_srs))
+            return false;
+
+        bool keyMercator = key_srs->isMercator() || key_srs->isSphericalMercator();
+        bool sourceMercator = source_srs->isMercator() || source_srs->isSphericalMercator();
+
+        bool mercatorGeographicPair =
+            (keyMercator && source_srs->isGeographic()) ||
+            (key_srs->isGeographic() && sourceMercator);
+
+        if (!mercatorGeographicPair)
+            return false;
+
+        const SpatialReference* keyGeographicSRS = keyMercator ? key_srs->getGeographicSRS() : key_srs;
+        const SpatialReference* sourceGeographicSRS = sourceMercator ? source_srs->getGeographicSRS() : source_srs;
+
+        return
+            keyGeographicSRS &&
+            sourceGeographicSRS &&
+            keyGeographicSRS->isHorizEquivalentTo(sourceGeographicSRS);
+    }
+
+    void buildRowInterpolatedReprojectionPoints(
+        const GeoExtent& extent,
+        unsigned cols,
+        unsigned rows,
+        const SpatialReference* source_srs,
+        const Bounds& sourceBounds,
+        std::vector<osg::Vec3d>& points)
+    {
+        auto* key_srs = extent.getSRS();
+        if (!canUseRowInterpolatedReprojection(key_srs, source_srs) || cols <= 1u || rows == 0u)
+        {
+            buildExactReprojectionPoints(extent, cols, rows, source_srs, sourceBounds, points);
+            return;
+        }
+
+        double minx, miny, maxx, maxy;
+        extent.getBounds(minx, miny, maxx, maxy);
+        double dx = (maxx - minx) / static_cast<double>(cols);
+        double dy = (maxy - miny) / static_cast<double>(rows);
+
+        double leftX = minx + 0.5 * dx;
+        double rightX = maxx - 0.5 * dx;
+        double centerX = minx + 0.5 * (maxx - minx);
+        double centerY = miny + 0.5 * (maxy - miny);
+
+        static thread_local std::vector<osg::Vec3d> axisPoints;
+        axisPoints.resize(rows + 2u);
+
+        axisPoints[0] = { leftX, centerY, 0.0 };
+        axisPoints[1] = { rightX, centerY, 0.0 };
+
+        for (unsigned t = 0u; t < rows; ++t)
+        {
+            double y = miny + (0.5 * dy) + (dy * static_cast<double>(t));
+            axisPoints[t + 2u] = { centerX, y, 0.0 };
+        }
+
+        if (!key_srs->transform(axisPoints, source_srs))
+        {
+            buildExactReprojectionPoints(extent, cols, rows, source_srs, sourceBounds, points);
+            return;
+        }
+
+        points.resize(cols * rows);
+
+        double invColSpan = 1.0 / static_cast<double>(cols - 1u);
+        bool clampToSourceBounds = sourceBounds.valid();
+
+        for (unsigned t = 0u; t < rows; ++t)
+        {
+            const auto& left = axisPoints[0];
+            const auto& right = axisPoints[1];
+            const auto& row = axisPoints[t + 2u];
+
+            for (unsigned s = 0u; s < cols; ++s)
+            {
+                double xmix = static_cast<double>(s) * invColSpan;
+                double leftMix = 1.0 - xmix;
+
+                osg::Vec3d& point = points[t * cols + s];
+                point.x() = leftMix * left.x() + xmix * right.x();
+                point.y() = row.y();
+                point.z() = 0.0;
+
+                if (clampToSourceBounds)
+                {
+                    clampPointToBounds(point, sourceBounds);
+                }
+            }
+        }
+    }
+
+    void buildInterpolatedReprojectionPoints(
+        const GeoExtent& extent,
+        unsigned cols,
+        unsigned rows,
+        const SpatialReference* source_srs,
+        const Bounds& sourceBounds,
+        std::vector<osg::Vec3d>& points)
+    {
+        auto* key_srs = extent.getSRS();
+        if (!source_srs || !key_srs || key_srs->isEquivalentTo(source_srs) || cols <= 2u || rows <= 2u)
+        {
+            buildExactReprojectionPoints(extent, cols, rows, source_srs, sourceBounds, points);
+            return;
+        }
+
+        if (canUseRowInterpolatedReprojection(key_srs, source_srs))
+        {
+            buildRowInterpolatedReprojectionPoints(extent, cols, rows, source_srs, sourceBounds, points);
+            return;
+        }
+
+        static thread_local std::vector<unsigned> meshCols;
+        static thread_local std::vector<unsigned> meshRows;
+        static thread_local std::vector<osg::Vec3d> meshPoints;
+
+        buildMeshAxis(cols, ASSEMBLE_IMAGE_REPROJECTION_MESH_SIZE, meshCols);
+        buildMeshAxis(rows, ASSEMBLE_IMAGE_REPROJECTION_MESH_SIZE, meshRows);
+
+        double minx, miny, maxx, maxy;
+        extent.getBounds(minx, miny, maxx, maxy);
+        double dx = (maxx - minx) / static_cast<double>(cols);
+        double dy = (maxy - miny) / static_cast<double>(rows);
+
+        unsigned meshWidth = static_cast<unsigned>(meshCols.size());
+        unsigned meshHeight = static_cast<unsigned>(meshRows.size());
+        meshPoints.resize(meshWidth * meshHeight);
+
+        for (unsigned mt = 0u; mt < meshHeight; ++mt)
+        {
+            unsigned t = meshRows[mt];
+            double y = miny + (0.5 * dy) + (dy * static_cast<double>(t));
+            for (unsigned ms = 0u; ms < meshWidth; ++ms)
+            {
+                unsigned s = meshCols[ms];
+                double x = minx + (0.5 * dx) + (dx * static_cast<double>(s));
+                meshPoints[mt * meshWidth + ms] = { x, y, 0.0 };
+            }
+        }
+
+        if (!key_srs->transform(meshPoints, source_srs))
+        {
+            buildExactReprojectionPoints(extent, cols, rows, source_srs, sourceBounds, points);
+            return;
+        }
+
+        points.resize(cols * rows);
+
+        unsigned rowCells = meshHeight > 1u ? meshHeight - 1u : 1u;
+        unsigned colCells = meshWidth > 1u ? meshWidth - 1u : 1u;
+        bool clampToSourceBounds = sourceBounds.valid();
+
+        for (unsigned my = 0u; my < rowCells; ++my)
+        {
+            unsigned my1 = meshHeight > 1u ? my + 1u : my;
+            unsigned t0 = meshRows[my];
+            unsigned t1 = meshRows[my1];
+            unsigned tEnd = my + 1u == rowCells ? t1 : t1 - 1u;
+            double invTSpan = t1 > t0 ? 1.0 / static_cast<double>(t1 - t0) : 0.0;
+
+            for (unsigned mx = 0u; mx < colCells; ++mx)
+            {
+                unsigned mx1 = meshWidth > 1u ? mx + 1u : mx;
+                unsigned s0 = meshCols[mx];
+                unsigned s1 = meshCols[mx1];
+                unsigned sEnd = mx + 1u == colCells ? s1 : s1 - 1u;
+                double invSSpan = s1 > s0 ? 1.0 / static_cast<double>(s1 - s0) : 0.0;
+
+                const auto& p00 = meshPoints[my * meshWidth + mx];
+                const auto& p10 = meshPoints[my * meshWidth + mx1];
+                const auto& p01 = meshPoints[my1 * meshWidth + mx];
+                const auto& p11 = meshPoints[my1 * meshWidth + mx1];
+
+                for (unsigned t = t0; t <= tEnd; ++t)
+                {
+                    double fy = static_cast<double>(t - t0) * invTSpan;
+                    double iy = 1.0 - fy;
+
+                    for (unsigned s = s0; s <= sEnd; ++s)
+                    {
+                        double fx = static_cast<double>(s - s0) * invSSpan;
+                        double ix = 1.0 - fx;
+
+                        osg::Vec3d& point = points[t * cols + s];
+                        point.x() = iy * (ix * p00.x() + fx * p10.x()) + fy * (ix * p01.x() + fx * p11.x());
+                        point.y() = iy * (ix * p00.y() + fx * p10.y()) + fy * (ix * p01.y() + fx * p11.y());
+                        point.z() = 0.0;
+
+                        if (clampToSourceBounds)
+                        {
+                            clampPointToBounds(point, sourceBounds);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 //------------------------------------------------------------------------
 
 void
@@ -676,7 +963,6 @@ ImageLayer::assembleImage(const TileKey& key, ProgressCallback* progress)
                 });
 
             // assume all tiles to mosaic are in the same SRS.
-            auto* key_srs = key.getExtent().getSRS();
             auto* source_srs = sources[0].second.getSRS();
 
             // new output:
@@ -687,41 +973,10 @@ ImageLayer::assembleImage(const TileKey& key, ProgressCallback* progress)
             // Working set of points. it's much faster to xform an entire vector all at once.
             // Reuse a thread_local vector to avoid memory allocation/deallocation subsequent calls
             static thread_local std::vector<osg::Vec3d> points;
-            points.resize(cols * rows);
-
-            double minx, miny, maxx, maxy;
-            key.getExtent().getBounds(minx, miny, maxx, maxy);
-            double dx = (maxx - minx) / (double)(cols);
-            double dy = (maxy - miny) / (double)(rows);
 
             Bounds sourceBounds;
             sources[0].second.getSRS()->getBounds(sourceBounds);
-
-            // build a grid of sample points:
-            for (unsigned t = 0; t < rows; ++t)
-            {
-                double y = miny + (0.5 * dy) + (dy * (double)t);
-                for (unsigned s = 0; s < cols; ++s)
-                {
-                    double x = minx + (0.5 * dx) + (dx * (double)s);
-                    points[t * cols + s] = { x, y, 0.0 };
-                }
-            }
-
-            // transform the sample points to the SRS of our source data tiles:
-            if (source_srs && key_srs)
-            {
-                key_srs->transform(points, source_srs);
-
-                if (sourceBounds.valid())
-                {
-                    for (auto& point : points)
-                    {
-                        point.x() = clamp(point.x(), sourceBounds.xMin(), sourceBounds.xMax());
-                        point.y() = clamp(point.y(), sourceBounds.yMin(), sourceBounds.yMax());
-                    }
-                }
-            }
+            buildInterpolatedReprojectionPoints(key.getExtent(), cols, rows, source_srs, sourceBounds, points);
 
             // Mosaic our sources into a single output image.
             std::vector<GeoImagePixelReader> readers;


### PR DESCRIPTION
## Summary

This speeds up `ImageLayer::assembleImage` when assembling imagery across coordinate systems by reducing how many output pixels need full coordinate reprojection before sampling source images.

For Mercator/geographic pairs, the transform is separable, so the code now transforms the horizontal axis endpoints and one vertical sample per row, then fills the output coordinate grid from those values. Other non-equivalent SRS pairs use a small interpolation mesh instead of per-pixel coordinate transforms, with exact fallback when interpolation is not appropriate or when a transform fails.

Coverage layers no longer force the exact coordinate-transform path; coverage behavior remains controlled by nearest-neighbor pixel sampling.

## Validation

- `build.bat`
- `cmd /c "call osgearth_shell.bat && cd tests && osgearth_tests"`
  - `33105 assertions in 33 test cases`
- `cmd /c "call osgearth_shell.bat && cd tests && osgearth_benchmarks --benchmark_filter=ImageLayerAssembleImage_Reproject --benchmark_min_time=0.5s"`
  - Before: `6.67 ms` real / `6.77 ms` CPU
  - After: `2.13 ms` real / `2.10 ms` CPU

## Notes

Added a focused benchmark for reprojection assembly and a regression test comparing the optimized path against exact per-pixel coordinate transforms for both imagery and coverage sampling.