### PR TITLE
[codex] Remove unused layer options

### DIFF
--- a/src/osgEarth/FeatureImageLayer
+++ b/src/osgEarth/FeatureImageLayer
@@ -27,9 +27,6 @@ namespace osgEarth
             OE_OPTION_VECTOR(ConfigOptions, filters);
             OE_OPTION_LAYER(StyleSheet, styleSheet);
             OE_OPTION(Distance, bufferWidth, {});
-            OE_OPTION(double, gamma);
-            OE_OPTION(bool, sdf);
-            OE_OPTION(bool, sdf_invert);
             OE_OPTION(Color, backgroundColor, Color::Transparent);
             virtual Config getConfig() const;
         private:
@@ -71,8 +68,6 @@ namespace osgEarth
         virtual ~FeatureImageLayer() { }
 
     private:
-        optional<double> _gamma;
-
         void updateSession();
 
         void establishProfile();

--- a/src/osgEarth/FeatureImageLayer.cpp
+++ b/src/osgEarth/FeatureImageLayer.cpp
@@ -27,9 +27,6 @@ FeatureImageLayer::Options::getConfig() const
     featureSource().set(conf, "features");
     styleSheet().set(conf, "styles");
     conf.set("buffer_width", bufferWidth());
-    conf.set("gamma", gamma());
-    conf.set("sdf", sdf());
-    conf.set("sdf_invert", sdf_invert());
     conf.set("background_color", backgroundColor());
 
     if (filters().empty() == false)
@@ -46,16 +43,9 @@ FeatureImageLayer::Options::getConfig() const
 void
 FeatureImageLayer::Options::fromConfig(const Config& conf)
 {
-    gamma().setDefault(1.3);
-    sdf().setDefault(false);
-    sdf_invert().setDefault(false);
-
     featureSource().get(conf, "features");
     styleSheet().get(conf, "styles");
     conf.get("buffer_width", bufferWidth());
-    conf.get("gamma", gamma());
-    conf.get("sdf", sdf());
-    conf.get("sdf_invert", sdf_invert());
     conf.get("background_color", backgroundColor());
 
     const Config& filtersConf = conf.child("filters");

--- a/src/osgEarth/GDAL
+++ b/src/osgEarth/GDAL
@@ -56,7 +56,6 @@ namespace osgEarth
             OE_OPTION(std::string, connection);
             OE_OPTION(unsigned, subDataSet, 0u);
             OE_OPTION(RasterInterpolation, interpolation, INTERP_BILINEAR);
-            OE_OPTION(ProfileOptions, warpProfile);
             OE_OPTION(bool, useVRT, false);
             OE_OPTION(bool, coverageUsesPaletteIndex, true);
             OE_OPTION(bool, singleThreaded, false);
@@ -272,10 +271,6 @@ namespace osgEarth
         //! GDAL sub-dataset index (optional)
         void setSubDataSet(const unsigned& value);
         const unsigned& getSubDataSet() const;
-
-        //! Forced profile for reprojection (still need this?)
-        void setWarpProfile(const ProfileOptions& value);
-        const ProfileOptions& getWarpProfile() const;
 
         //! Interpolation method for resampling (default is bilinear)
         void setInterpolation(const RasterInterpolation& value);

--- a/src/osgEarth/ImageLayer
+++ b/src/osgEarth/ImageLayer
@@ -52,13 +52,10 @@ namespace osgEarth
         public:
             META_LayerOptions(osgEarth, Options, TileLayer::Options);
             OE_OPTION(URI, noDataImageFilename);
-            OE_OPTION(osg::Vec4ub, transparentColor, osg::Vec4ub(0, 0, 0, 0));
             OE_OPTION(ColorFilterChain, colorFilters);
             OE_OPTION(osg::Texture::FilterMode, minFilter, osg::Texture::LINEAR_MIPMAP_LINEAR);
             OE_OPTION(osg::Texture::FilterMode, magFilter, osg::Texture::LINEAR);
             OE_OPTION(std::string, textureCompression);
-            OE_OPTION(double, edgeBufferRatio, 0.0);
-            OE_OPTION(unsigned, reprojectedTileSize, 256u);
             OE_OPTION(Distance, altitude);
             OE_OPTION(bool, coverage, false);
             OE_OPTION(bool, acceptDraping, false);

--- a/src/osgEarth/ImageLayer.cpp
+++ b/src/osgEarth/ImageLayer.cpp
@@ -32,11 +32,6 @@ ImageLayer::Options::fromConfig(const Config& conf)
     conf.get( "coverage",       _coverage );
     conf.get( "altitude",       _altitude );
     conf.get( "accept_draping", acceptDraping());
-    conf.get( "edge_buffer_ratio", _edgeBufferRatio);
-    conf.get( "reprojected_tilesize", _reprojectedTileSize);
-
-    if ( conf.hasValue( "transparent_color" ) )
-        _transparentColor = stringToColor( conf.value( "transparent_color" ), osg::Vec4ub(0,0,0,0));
 
     if ( conf.hasChild("color_filters") )
     {
@@ -81,11 +76,6 @@ ImageLayer::Options::getConfig() const
     conf.set( "coverage",       _coverage );
     conf.set( "altitude",       _altitude );
     conf.set( "accept_draping", acceptDraping());
-    conf.set( "edge_buffer_ratio", _edgeBufferRatio);
-    conf.set( "reprojected_tilesize", _reprojectedTileSize);
-
-    if (_transparentColor.isSet())
-        conf.set("transparent_color", colorToString( _transparentColor.value()));
 
     if ( _colorFilters->size() > 0 )
     {

--- a/src/osgEarth/LandCover
+++ b/src/osgEarth/LandCover
@@ -167,7 +167,6 @@ namespace osgEarth
         class OSGEARTH_EXPORT Options : public Layer::Options {
         public:
             META_LayerOptions(osgEarth, Options, Layer::Options);
-            OE_OPTION(float, warp);
             OE_OPTION(ConfigOptions, layer);
             LandCoverValueMappingVector& mappings() { return _mappings; }
             const LandCoverValueMappingVector& mappings() const { return _mappings; }
@@ -190,10 +189,6 @@ namespace osgEarth
         //! Land cover dictionary to use.
         void setDictionary(LandCoverDictionary* value) { _lcDictionary = value; }
         LandCoverDictionary* getDictionary() const { return _lcDictionary.get(); }
-
-        //! Sets the warping amount
-        void setWarp(const float& value);
-        const float& getWarp() const;
 
         //! Sets the underlying image layer
         void setImageLayer(ImageLayer* value);

--- a/src/osgEarth/LandCover.cpp
+++ b/src/osgEarth/LandCover.cpp
@@ -285,16 +285,12 @@ LandCoverValueMapping::getConfig() const
 void
 LandCoverCoverageLayer::Options::fromConfig(const Config& conf)
 {
-    warp().init(0.0f);
-
     ConfigSet mappingsConf = conf.child("land_cover_mappings").children("mapping");
     for (ConfigSet::const_iterator i = mappingsConf.begin(); i != mappingsConf.end(); ++i)
     {
         osg::ref_ptr<LandCoverValueMapping> mapping = new LandCoverValueMapping(*i);
         mappings().push_back(mapping.get());
     }
-
-    conf.get("warp", warp());
 
     for(ConfigSet::const_iterator i = conf.children().begin(); i != conf.children().end(); ++i)
     {
@@ -325,8 +321,6 @@ LandCoverCoverageLayer::Options::getConfig() const
                 mappingConf.add(mapping->getConfig());
         }
     }
-    conf.set("warp", warp());
-
     if (layer().isSet())
         conf.set(layer()->getConfig());
 
@@ -350,10 +344,6 @@ LandCoverCoverageLayer::Options::map(int value, const std::string& lcClass)
 {
     mappings().push_back(new LandCoverValueMapping(value, lcClass));
 }
-
-//...................................................................
-
-OE_LAYER_PROPERTY_IMPL(LandCoverCoverageLayer, float, Warp, warp);
 
 Status
 LandCoverCoverageLayer::openImplementation()

--- a/src/osgEarth/Layer
+++ b/src/osgEarth/Layer
@@ -178,7 +178,6 @@ namespace osgEarth
             OE_OPTION(CachePolicy, cachePolicy);
             OE_OPTION(std::string, shaderDefine);
             OE_OPTION(std::string, attribution);
-            OE_OPTION(ShaderOptions, shader);
             OE_OPTION_VECTOR(ShaderOptions, shaders);
             OE_OPTION(ProxySettings, proxySettings);
             OE_OPTION(std::string, osgOptionString);

--- a/src/osgEarth/UTMGraticule
+++ b/src/osgEarth/UTMGraticule
@@ -30,7 +30,6 @@ namespace osgEarth { namespace Util
         public:
             META_LayerOptions(osgEarth, Options, VisibleLayer::Options);
             OE_OPTION(Style, gzdStyle);
-            OE_OPTION(float, textScale);
             virtual Config getConfig() const;
         private:
             void fromConfig(const Config& conf);
@@ -42,10 +41,6 @@ namespace osgEarth { namespace Util
         //! Style for the Grid Zone Designator graphics
         void setGZDStyle(const Style& value);
         const Style& getGZDStyle() const;
-
-        //! Text scale factor (default = 1)
-        void setTextScale(const float& value);
-        const float& getTextScale() const;
 
         //! If you change any of the options, call this to refresh the display
         //! and apply the new settings.

--- a/src/osgEarth/UTMGraticule.cpp
+++ b/src/osgEarth/UTMGraticule.cpp
@@ -175,7 +175,6 @@ UTMGraticule::Options::getConfig() const
 {
     Config conf = VisibleLayer::Options::getConfig();
     conf.set("gzd_style", gzdStyle() );
-    conf.set("text_scale", textScale() );
     return conf;
 }
 
@@ -183,13 +182,11 @@ void
 UTMGraticule::Options::fromConfig(const Config& conf)
 {
     conf.get("gzd_style", gzdStyle() );
-    conf.get("text_scale", textScale() );
 }
 
 //...................................................................
 
 OE_LAYER_PROPERTY_IMPL(UTMGraticule, Style, GZDStyle, gzdStyle);
-OE_LAYER_PROPERTY_IMPL(UTMGraticule, float, TextScale, textScale);
 
 void
 UTMGraticule::dirty()

--- a/src/osgEarth/WMS
+++ b/src/osgEarth/WMS
@@ -333,7 +333,6 @@ namespace osgEarth { namespace WMS
         OE_OPTION(std::string, crs);
         OE_OPTION(bool, transparent);
         OE_OPTION(std::string, times);
-        OE_OPTION(double, secondsPerFrame);
 
         static Config getMetadata();
         virtual Config getConfig() const;

--- a/src/osgEarth/WMS.cpp
+++ b/src/osgEarth/WMS.cpp
@@ -357,7 +357,6 @@ WMS::WMSImageLayerOptions::getConfig() const
     conf.set("crs", _crs);
     conf.set("transparent", _transparent);
     conf.set("times", _times);
-    conf.set("seconds_per_frame", _secondsPerFrame);
     return conf;
 }
 
@@ -366,7 +365,6 @@ WMS::WMSImageLayerOptions::fromConfig(const Config& conf)
 {
     _wmsVersion.init("1.1.1");
     _transparent.init(true);
-    _secondsPerFrame.init(1.0);
 
     conf.get("url", _url);
     conf.get("capabilities_url", _capabilitiesUrl);
@@ -380,7 +378,6 @@ WMS::WMSImageLayerOptions::fromConfig(const Config& conf)
     conf.get("transparent", _transparent);
     conf.get("times", _times);
     conf.get("time", _times); // alternative
-    conf.get("seconds_per_frame", _secondsPerFrame);
 }
 
 //........................................................................

--- a/src/osgEarthImGui/LifeMapLayerGUI
+++ b/src/osgEarthImGui/LifeMapLayerGUI
@@ -148,7 +148,6 @@ namespace osgEarth
 
                     ImGuiLTable::SliderFloat("Terrain contrib", &o.terrainWeight().mutable_value(), 0.0f, 1.0f);
                     //ImGuiLTable::SliderFloat("Slope contrib", &o.slopeIntensity().mutable_value(), 1.0f, 10.0f);
-                    //ImGuiLTable::SliderFloat("Slope cutoff", &o.slopeCutoff().mutable_value(), 0.0f, 1.0f);
 
                     ImGuiLTable::SliderFloat("Noise contrib", &o.noiseWeight().mutable_value(), 0.0f, 1.0f);
 

--- a/src/osgEarthProcedural/LifeMapLayer
+++ b/src/osgEarthProcedural/LifeMapLayer
@@ -39,10 +39,8 @@ namespace osgEarth { namespace Procedural
             OE_OPTION(Distance, landCoverBlur, Distance(0.0f, Units::METERS));
             OE_OPTION(float, terrainWeight, 1.0f);
             OE_OPTION(float, slopeIntensity, 1.0f);
-            OE_OPTION(float, slopeCutoff, 0.0f);
             OE_OPTION(float, colorWeight, 1.0f);
             OE_OPTION(float, noiseWeight, 0.225f);
-            OE_OPTION(float, lushFactor, 1.9f);
 
             virtual Config getConfig() const;
         private:

--- a/src/osgEarthProcedural/LifeMapLayer.cpp
+++ b/src/osgEarthProcedural/LifeMapLayer.cpp
@@ -33,7 +33,6 @@ LifeMapLayer::Options::getConfig() const
     conf.set("terrain_weight", terrainWeight());
     conf.set("color_weight", colorWeight());
     conf.set("noise_weight", noiseWeight());
-    conf.set("lush_factor", lushFactor());
     return conf;
 }
 
@@ -50,7 +49,6 @@ LifeMapLayer::Options::fromConfig(const Config& conf)
     conf.get("terrain_weight", terrainWeight());
     conf.get("color_weight", colorWeight());
     conf.get("noise_weight", noiseWeight());
-    conf.get("lush_factor", lushFactor());
 }
 
 //........................................................................
@@ -826,9 +824,6 @@ LifeMapLayer::createImageImplementation(
 
                 // apply the noise additively:
                 combined_pixel += pixel[NOISE] * weight[NOISE];
-
-                // apply the lushness static factor
-                //combined_pixel[LIFEMAP_LUSH] *= options().lushFactor().get();
 
                 // MASK CONTRIBUTION (applied to final combined pixel data)
                 if (densityMask.valid())

--- a/src/osgEarthProcedural/VegetationLayer
+++ b/src/osgEarthProcedural/VegetationLayer
@@ -52,10 +52,6 @@ namespace osgEarth { namespace Procedural
             //! default = true
             OE_OPTION(bool, useImpostorPBRMaps, true);
 
-            //! Whether to assume normal maps are RG-compressed
-            //! default = true;
-            OE_OPTION(bool, useRGCompressedNormalMaps, true);
-
             //! Scale factor for LOD-ing the far-away impostor vegetation
             //! default = 1.0f
             OE_OPTION(float, farLODScale, 1.0f);


### PR DESCRIPTION
﻿## Summary

Removes unused `OE_OPTION` fields from layer option classes and deletes the corresponding dead config/property plumbing.

The cleanup covers unused options in feature image, image, GDAL, land cover, UTM graticule, WMS, LifeMap, and vegetation layer option surfaces. The plural `shaders` option remains in `Layer::Options`; only the unused singular `shader` option was removed.

## Validation

- Ran a custom repo scan accounting for generated `getXXX`/`setXXX` accessors: `zero actual refs 0`
- Ran removed-name `rg` sweep; remaining hits were unrelated comments/local parameters
- `git diff --cached --check`
- `configure.bat`
- `build.bat`
