### PR TITLE
Text: Position Offsets and Callouts scale correctly by DPR. Stipple for LineDrawable now scales by DPR.

### DIFF
--- a/src/osgEarth/LineDrawable.glsl
+++ b/src/osgEarth/LineDrawable.glsl
@@ -199,6 +199,7 @@ void oe_LineDrawable_VS_CLIP(inout vec4 currClip)
 
 uniform int oe_GL_LineStippleFactor;
 uniform int oe_GL_LineStipplePattern;
+uniform float oe_dpr = 1.0;
 
 flat in vec2 oe_LineDrawable_rv;
 flat in int oe_LineDrawable_draw;
@@ -215,7 +216,7 @@ void oe_LineDrawable_Stippler_FS(inout vec4 color)
     if (oe_GL_LineStipplePattern != 0xffff)
     {
         // coordinate of the fragment, shifted to 0:
-        vec2 coord = (gl_FragCoord.xy - 0.5);
+        vec2 coord = (gl_FragCoord.xy - 0.5) / oe_dpr;
 
         // rotate the frag coord onto the X-axis so we can sample the 
         // stipple pattern:

--- a/src/osgEarth/ScreenSpaceLayoutCallout
+++ b/src/osgEarth/ScreenSpaceLayoutCallout
@@ -343,11 +343,13 @@ namespace osgEarth { namespace Internal
 
         if (element._declutter && ScreenSpaceLayout::globallyEnabled)
         {
-            double leaderLen = osg::minimum((double)_context->_options.leaderLineMaxLength().get(), element._offsetLength);
+            // Scale the logical max length into physical pixels so the label can float far enough away
+            const double maxLeaderLenPhys = _context->_options.leaderLineMaxLength().get() * local._dprscale.x();
+            const double leaderLen = osg::minimum(maxLeaderLenPhys, element._offsetLength);
             osg::Vec3d pos = element._anchor + element._offsetVector*leaderLen;
 
             // alignment of text relative to the leader line
-            const float margin = 5.0f;
+            const float margin = 5.0f * local._dprscale.x();
             osg::Vec3d alignment;
             osg::BoundingBox box = element._drawable->getBoundingBox();
 
@@ -398,6 +400,10 @@ namespace osgEarth { namespace Internal
         }
         else
         {
+            // Multiply the logical offset by the DPR before adding it to the anchor
+            offset.x() *= local._dprscale.x();
+            offset.y() *= local._dprscale.y();
+
             leaf->_modelview->makeTranslate(element._anchor + offset);
             leaf->_modelview->preMultScale(local._dprscale);
         }
@@ -430,7 +436,7 @@ namespace osgEarth { namespace Internal
             std::vector<Element*> elements;
         };
 
-        const double clusterDistance = 4.0;
+        const double clusterDistance = 4.0 * local._dprscale.x();
         const double clusterDistance2 = clusterDistance * clusterDistance;
         std::vector<SiteCluster> siteClusters;
 


### PR DESCRIPTION
I've been successful at getting SIMDIS rendering with high DPR. I have found some very minor issues that this fixes:
* Labels with pixel offsets now treat those as logical pixels.
* Callouts now scale away from their tether position in logical pixels
* Stipples are impacted by DPR
