### PR TITLE
Fix a null access crash and buffer overflow issue found in WMS layer requests

### DIFF
--- a/src/osgEarth/ArcGISServer.cpp
+++ b/src/osgEarth/ArcGISServer.cpp
@@ -689,6 +689,10 @@ ArcGISServerElevationLayer::closeImplementation()
 GeoHeightField
 ArcGISServerElevationLayer::createHeightFieldImplementation(const TileKey& key, ProgressCallback* progress) const
 {
+    // Avoid accessing null _imageLayer in case layer was deleted
+    if (getStatus().isError() || !_imageLayer)
+      return GeoHeightField(getStatus());
+
     // Make an image, then convert it to a heightfield
     GeoImage image = _imageLayer->createImageImplementation(key, progress);
     if (image.valid())

--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -1037,17 +1037,13 @@ namespace
                 urlcomp.nScheme == INTERNET_SCHEME_HTTPS ? INTERNET_DEFAULT_HTTPS_PORT :
                 INTERNET_DEFAULT_HTTP_PORT;
 
-            char hostName[128];
-            char urlPath[256];
-            memset(urlPath, 0, sizeof(urlPath));
-            memset(hostName, 0, sizeof(hostName));
-            strncpy(hostName, urlcomp.lpszHostName, urlcomp.dwHostNameLength);
-            strncpy(urlPath, urlcomp.lpszUrlPath, urlcomp.dwUrlPathLength);
+            std::string hostName(urlcomp.lpszHostName, urlcomp.dwHostNameLength);
+            std::string urlPath(urlcomp.lpszUrlPath, urlcomp.dwUrlPathLength);
 
             OE_TEST
                 << "\n"
                 << "Host name = " << hostName << "\n"
-                << "Url path = " << urlcomp.lpszUrlPath << "\n"
+                << "Url path = " << urlPath << "\n"
                 << "Port = " << port << "\n";
 
             DWORD openFlags =
@@ -1067,7 +1063,7 @@ namespace
 
             HINTERNET hConnection = InternetConnect(
                 hInternet,
-                hostName,
+                hostName.c_str(),
                 port,
                 "", // username
                 "", // password
@@ -1089,7 +1085,7 @@ namespace
             HINTERNET hRequest = HttpOpenRequest(
                 hConnection,            // handle from InternetConnect
                 "GET",                  // verb
-                urlPath,                // path
+                urlPath.c_str(),        // path
                 NULL,                   // HTTP version (NULL = default)
                 NULL,                   // Referrer
                 NULL,                   // Accept types


### PR DESCRIPTION
Encountered these potential crashes when working with WMS layers in SIMDIS. 

1. The ArcGISServer method was blindly accessing _imageLayer, and if it had been deleted was causing a crash to desktop
2. The HttpClient method was overflowing the char buffer if the input Request URL was longer than 256 characters, which seems quite easy to do

Verified both fixes functioned in osgearth_viewer and SIMDIS