### PR TITLE
LineDrawable: Changing Vertices will dirtyBound() the inner geometry

### DIFF
--- a/src/osgEarth/LineDrawable.cpp
+++ b/src/osgEarth/LineDrawable.cpp
@@ -646,6 +646,7 @@ LineDrawable::setFirst(unsigned value)
 {
     _first = value;
     updateFirstCount();
+    _geom->dirtyBound();
 }
 
 unsigned
@@ -659,6 +660,7 @@ LineDrawable::setCount(unsigned value)
 {
     _count = value;
     updateFirstCount();
+    _geom->dirtyBound();
 }
 
 unsigned
@@ -982,6 +984,7 @@ LineDrawable::setVertex(unsigned vi, const osg::Vec3& vert)
         }
 
         dirtyBound();
+        _geom->dirtyBound();
     }
 }
 
@@ -1164,6 +1167,7 @@ LineDrawable::dirty()
     initialize();
 
     dirtyBound();
+    _geom->dirtyBound();
 
     _current->dirty();
 


### PR DESCRIPTION
This fixes observed culling problems, especially with the use of `setFirst` / `setCount` in the SIMDIS SDK's Track History code, which extensively uses `LineDrawable`.

Most calls for node bounds are forwarded to the inner `_geom` class, but `dirtyBound()` is not, because it cannot be, because it is not a virtual method. Calling `LineDrawable::dirtyBound()` is not helpful in cases where `setFirst` or `setCount` especially are used, because it ends up not changing the bounds of the `_geom`. This causes that line geometry to get culled in some unfortunate cases.

For example, we build up track history lines as new data points come in for our Platform class. We do this in chunks (`simVis/TrackChunkNode.cpp`). So when a new chunk is created, it starts with one point and fills up gradually as new points arrive. This works great, but the culling is "locked" to that first point, and if it falls out of the view frustum the entire chunk gets hidden. This can be confirmed by printing the bounding box data on the `LineDrawable::_geom`. That problem goes away with this set of fixes.