### PR TITLE
Config: Fixed indeterminate crash from access of global EMPTY_STRING in static initialization

### DIFF
--- a/src/osgEarth/Config
+++ b/src/osgEarth/Config
@@ -408,7 +408,11 @@ namespace osgEarth
         template<typename T>
         T value(const std::string& key, T fallback) const {
             const Config* conf = child_ptr(key);
-            return osgEarth::Util::as<T>(conf ? conf->value() : EMPTY_STRING, fallback);
+            if (conf)
+                return osgEarth::Util::as<T>(conf->value(), fallback);
+
+            static const std::string empty;
+            return osgEarth::Util::as<T>(empty, fallback);
         }
 
         /** Populates the output value iff the Config exists. */


### PR DESCRIPTION
We build osgEarth master as part of our nightly build, even though we don't update daily. We then test it against our suite of unit tests. A little over a week ago we started to have segfaults in these nightly sanity tests on Linux (gcc-15). Yesterday I tried to build master and run and kept getting crashes on MSVC, although a colleague was able to run the same commit without problems on their system.

I traced the issue to b7ebbe73f where `EMPTY_STRING` started being used in `Config::value()`. There is a race condition on static initialization order, where `Config` is used in some static initialization cases, and relies on `EMPTY_STRING` being initialized. But there's no guarantee that it will be initialized. This was leading to a crash on Linux and at least one Windows system.

The fix is here, simply lazily initializing a static empty string with a determinate initialization order.  Tested on gcc-15.