### PR TITLE
Fix sky lighting contrast and ambient defaults

### DIFF
--- a/src/osgEarthDrivers/sky_gl/GLSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_gl/GLSkyNode.cpp
@@ -35,15 +35,10 @@ GLSkyNode::construct()
 
     _light = new LightGL3(0);
     _light->setDataVariance(_light->DYNAMIC);
-    _light->setAmbient(osg::Vec4(0.1f, 0.1f, 0.1f, 1.0f));
+    float ambient = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
+    _light->setAmbient(osg::Vec4(ambient, ambient, ambient, 1.0f));
     _light->setDiffuse(osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
     _light->setSpecular(osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
-
-    if ( _options.ambient().isSet() )
-    {
-        float a = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
-        _light->setAmbient(osg::Vec4(a, a, a, 1.0f));
-    }
 
     // installs the main uniforms and the shaders that will light the subgraph (terrain).
     osg::StateSet* stateset = this->getOrCreateStateSet();

--- a/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
+++ b/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
@@ -8,7 +8,7 @@
 
 uniform float oe_sky_exposure = 3.3; // HDR scene exposure (ground level)
 uniform float oe_sky_ambientBoostFactor; // ambient sunlight booster for daytime (material mode only)
-uniform float oe_sky_maxAmbientIntensity = 0.75; // maximum daytime ambient intensity (PBR mode only)
+uniform float oe_sky_maxAmbientIntensity = 0.15; // maximum daytime ambient intensity (PBR mode only)
 
 in vec3 atmos_lightDir;    // light direction (view coords)
 in vec3 atmos_color;       // atmospheric lighting color
@@ -105,8 +105,13 @@ vec3 atmos_safeNormalize(vec3 value, vec3 fallback)
     return length2 > 1e-12 ? value * inversesqrt(length2) : fallback;
 }
 
-const float oe_wrap = 0.22;
-uniform float oe_normal_boost = 1.0;
+float atmos_sunVisibility(float sunElevation)
+{
+    // Fade across the horizon (about 0.6 degrees on either side). Above it,
+    // let NdotL control direct sunlight instead of dimming every surface by
+    // the sun's elevation. Below it, prevent light from shining through Earth.
+    return smoothstep(-0.01, 0.01, sunElevation);
+}
 
 #ifdef OE_USE_PBR
 void atmos_fragment_main_pbr(inout vec4 color)
@@ -126,7 +131,9 @@ void atmos_fragment_main_pbr(inout vec4 color)
     F0 = mix(F0, albedo, vec3(oe_pbr.metal));
 
     vec3 Lo = vec3(0.0);
-    float ai = 0.0; // ambient intensity (based on time of day)
+    vec3 ambientLight = vec3(0.0);
+    // Approximate the visible sky hemisphere independently of the sun direction.
+    float skyVisibility = clamp(0.5 + 0.5 * dot(N, U), 0.0, 1.0);
 
     for (int i = 0; i < OE_NUM_LIGHTS; ++i)
     {
@@ -145,16 +152,12 @@ void atmos_fragment_main_pbr(inout vec4 color)
 
         float NdotL = max(dot(N, L), 0.0);
 
-        // wrap diffuse:
-        // https://developer.nvidia.com/gpugems/gpugems/part-iii-materials/chapter-16-real-time-approximations-subsurface-scattering
-        float NdotL_wrap = max(0.0, (NdotL + oe_wrap) / (1.0 + oe_wrap));
-
         float NdotV = max(0.0, dot(N, V));
 
         // cook-torrance BRDF:
         float roughness = clamp(oe_pbr.roughness, 0.0, 1.0);
         float NDF = DistributionGGX(N, H, roughness);
-        float G = GeometrySmith(NdotV, NdotL_wrap, roughness);
+        float G = GeometrySmith(NdotV, NdotL, roughness);
         vec3 F = FresnelSchlick(max(dot(H, V), 0.0), F0);
 
         vec3 kS = F;
@@ -162,20 +165,28 @@ void atmos_fragment_main_pbr(inout vec4 color)
         kD *= 1.0 - oe_pbr.metal;
 
         vec3 numerator = NDF * G * F;
-        float denominator = 4.0 * max(dot(N, V), 0.0) * NdotL_wrap;
+        float denominator = 4.0 * NdotV * NdotL;
         vec3 specular = NdotL > 0.0 ? numerator / max(denominator, 0.001) : vec3(0.0);
 
-        // daytime metric
-        float day = i == 0 ? max(0.0, dot(U, L)) : 1.0;
+        float sunElevation = dot(U, L);
+        float sunVisibility = i == 0 ? atmos_sunVisibility(sunElevation) : 1.0;
 
-        // color contribution
-        Lo += (kD * albedo / PI + specular) * radiance * NdotL_wrap * day;
+        // Direct light uses the actual surface normal, including normal maps.
+        Lo += (kD * albedo / PI + specular) * radiance * NdotL * sunVisibility;
 
-        // ambient intesntity contribution
-        ai = max(ai, NdotL_wrap * oe_sky_maxAmbientIntensity) * day;
+        vec3 lightAmbient = osg_LightSource[i].ambient.rgb;
+        if (i == 0)
+        {
+            // Keep the night-time minimum, and fade toward the daytime sky
+            // fill. Do not add another NdotL-based light on top of the BRDF.
+            vec3 skyAmbient = vec3(oe_sky_maxAmbientIntensity * skyVisibility);
+            lightAmbient = mix(lightAmbient, max(lightAmbient, skyAmbient),
+                clamp(sunElevation, 0.0, 1.0));
+        }
+        ambientLight += lightAmbient;
     }
 
-    vec3 ambient = clamp(osg_LightSource[0].ambient.rgb + vec3(ai), 0.0, 1.0) * albedo * oe_pbr.ao;
+    vec3 ambient = clamp(ambientLight, 0.0, 1.0) * albedo * oe_pbr.ao;
 
     color.rgb = ambient + Lo;
 
@@ -274,14 +285,12 @@ void atmos_fragment_material(inout vec4 color)
 
             float NdotL = max(dot(N,L), 0.0);
 
-            // this term, applied to light 0 (the sun), attenuates the diffuse light
-            // during the nighttime, so that geometry doesn't get lit based on its
-            // normals during the night.
-            float diffuseAttenuation = clamp(dayTerm+0.35, 0.0, 1.0);
+            // Apply the same horizon visibility to diffuse and specular sunlight.
+            float sunVisibility = i == 0 ? atmos_sunVisibility(dayTerm) : 1.0;
 
             vec3 diffuseReflection =
                 attenuation
-                * diffuseAttenuation
+                * sunVisibility
                 * osg_LightSource[i].diffuse.rgb
                 * NdotL;
 
@@ -298,6 +307,7 @@ void atmos_fragment_material(inout vec4 color)
                 specularReflection =
                       specAttenuation
                     * attenuation
+                    * sunVisibility
                     * osg_LightSource[i].specular.rgb
                     * surfaceSpecularity.rgb
                     * pow(HdotV, shine);

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -212,7 +212,8 @@ SimpleSkyNode::construct()
 
     _light = new LightGL3(0);
     _light->setPosition(osg::Vec4f(0.0f, 0.0f, 1.0f, 0.0f));
-    _light->setAmbient(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f));
+    float ambient = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
+    _light->setAmbient(osg::Vec4f(ambient, ambient, ambient, 1.0f));
     _light->setDiffuse(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f));
     _light->setSpecular(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)); // does nothing in PBR mode
 
@@ -222,12 +223,6 @@ SimpleSkyNode::construct()
     lightSource->setCullingActive(false);
     _cullContainer->addChild(lightSource);
     lightSource->addCullCallback(new LightSourceGL3UniformGenerator());
-
-    if (_options.ambient().isSet())
-    {
-        float a = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
-        _light->setAmbient(osg::Vec4(a, a, a, 1.0f));
-    }
 
     // only supports geocentric for now.
     if (getReferencePoint().isValid())

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
@@ -27,7 +27,7 @@ namespace osgEarth {
                 _allowWireframe(false),
                 _starSize(14.0f),
                 _moonScale(2.0f),
-                _maxAmbientIntensity(0.75f),
+                _maxAmbientIntensity(0.15f),
                 _moonImageURI("moon_1024x512.jpg"),
                 _sunVisible(true),
                 _moonVisible(true),
@@ -58,7 +58,7 @@ namespace osgEarth {
             optional<float>& daytimeAmbientBoost() { return _daytimeAmbientBoost; }
             const optional<float>& daytimeAmbientBoost() const { return _daytimeAmbientBoost; }
 
-            //! Maximum ambient value at high noon. Default=0.75
+            //! Maximum daytime ambient intensity. Default=0.15
             optional<float>& maxAmbientIntensity() { return _maxAmbientIntensity; }
             const optional<float>& maxAmbientIntensity() const { return _maxAmbientIntensity; }
 

--- a/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
+++ b/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
@@ -10,7 +10,7 @@ header = R"(
 
 pbr = R"(
 
-uniform float oe_sky_maxAmbientIntensity = 0.75;
+uniform float oe_sky_maxAmbientIntensity = 0.15;
 
 // https://learnopengl.com/PBR/Lighting
 
@@ -174,7 +174,7 @@ in vec3 atmos_ambient;
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
 {    
 #ifdef OE_LIGHTING
-    vec3 N = vp_Normal; //gl_FrontFacing ? vp_Normal : -vp_Normal;
+    vec3 N = normalize(vp_Normal);
 	vec3 sky_irradiance;
 	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
 	vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);
@@ -294,7 +294,7 @@ const vec3 white_point = vec3(1,1,1);
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
 {
 #ifdef OE_LIGHTING
-    vec3 N = vp_Normal; //gl_FrontFacing ? vp_Normal : -vp_Normal;
+    vec3 N = normalize(vp_Normal);
 	vec3 sky_irradiance;
 	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
     vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);

--- a/src/osgEarthImGui/EnvironmentGUI
+++ b/src/osgEarthImGui/EnvironmentGUI
@@ -87,10 +87,10 @@ namespace osgEarth
         bool _showDetails = false;
         float _hour;
         int _day, _month, _year;
-        float _exposure = 3.5f;
+        float _exposure = 3.3f;
         float _contrast = 1.0f;
         float _ambient = 0.033f;
-        float _max_ambient_intensity = 0.75;
+        float _max_ambient_intensity = 0.15f;
         bool _first = true;
         bool _shadows = false;
         float _haze_cutoff = 0.0f, _haze_strength = 16.0f;
@@ -110,6 +110,7 @@ namespace osgEarth
             conf.get("Exposure", _exposure);
             conf.get("Contrast", _contrast);
             conf.get("Ambient", _ambient);
+            conf.get("AmbientMax", _max_ambient_intensity);
             conf.get("HazeCutoff", _haze_cutoff);
             conf.get("HazeStrength", _haze_strength);
             conf.get("WindPower", _wind_power);
@@ -120,6 +121,7 @@ namespace osgEarth
             conf.set("Exposure", _exposure);
             conf.set("Contrast", _contrast);
             conf.set("Ambient", _ambient);
+            conf.set("AmbientMax", _max_ambient_intensity);
             conf.set("HazeCutoff", _haze_cutoff);
             conf.set("HazeStrength", _haze_strength);
             conf.set("WindPower", _wind_power);


### PR DESCRIPTION
With `osgearth_imgui --sky`, diffuse wrapping lights surfaces facing away from the sun, while a sun-elevation multiplier makes nearby surfaces brighten together. Use the actual surface normal for direct sunlight and reserve sun-elevation-dependent fill for ambient lighting.

- Remove O'Neil diffuse wrapping and use a narrow horizon fade for direct sunlight, including the material path's specular lighting.
- Honor the configured ambient value in both sky drivers, including the default of 0.033. Reduce the default maximum daytime ambient intensity from 0.75 to 0.15 and use sky-hemisphere ambient fill in the O'Neil PBR path.
- Normalize fragment normals before Bruneton lighting calculations.
- Match the ImGui exposure and ambient defaults to the sky settings and persist the Ambient max control.

Validation: `git diff --check` passes. Numerical checks of the shader equations cover back-facing and tangent surfaces, low-angle sunlight, the horizon fade, other lights at night, and ambient limits. Build and visual testing are pending.