### PR TITLE
Improve sky environment lighting and add time-of-day playback

### DIFF
--- a/src/osgEarth/PhongLighting.glsl
+++ b/src/osgEarth/PhongLighting.glsl
@@ -25,6 +25,11 @@ void oe_phong_vertex(inout vec4 VertexVIEW)
 
 #pragma import_defines(OE_LIGHTING)
 #pragma import_defines(OE_NUM_LIGHTS)
+#pragma import_defines(OE_SHADOWING)
+
+#ifdef OE_SHADOWING
+float oe_shadow_visibility;
+#endif
 
 #ifdef OE_LIGHTING
 
@@ -124,9 +129,14 @@ void oe_phong_fragment(inout vec4 color)
                 osg_LightSource[i].ambient.rgb;
 
             float NdotL = max(dot(N,L), 0.0); 
+            float visibility = 1.0;
+#ifdef OE_SHADOWING
+            if (i == 0) visibility = oe_shadow_visibility;
+#endif
 
             vec3 diffuseReflection =
                 attenuation
+                * visibility
                 * osg_LightSource[i].diffuse.rgb
                 * NdotL;
                 
@@ -138,6 +148,7 @@ void oe_phong_fragment(inout vec4 color)
 
                 specularReflection =
                     attenuation
+                    * visibility
                     * osg_LightSource[i].specular.rgb
                     * surfaceSpecularity
                     * pow(HdotV, shine);

--- a/src/osgEarth/ShadowCaster.glsl
+++ b/src/osgEarth/ShadowCaster.glsl
@@ -26,7 +26,7 @@ void oe_shadow_vertex(inout vec4 VertexVIEW)
 #pragma vp_name       Shadowing Fragment Shader
 #pragma vp_entryPoint oe_shadow_fragment
 #pragma vp_location   fragment_lighting
-#pragma vp_order      0.7
+#pragma vp_order      0.1
 
 #pragma import_defines(OE_LIGHTING)
 #pragma import_defines(OE_NUM_LIGHTS)
@@ -39,8 +39,8 @@ in vec3 vp_Normal; // stage global
 in vec4 oe_shadow_coord[$OE_SHADOW_NUM_SLICES];
 in float oe_shadow_rf;
 
-// fragment stage global PBR parameters.
-struct OE_PBR { float displacement, roughness, ao, metal; } oe_pbr;
+// Stage global, consumed by the lighting shaders for light zero only.
+float oe_shadow_visibility;
 
 // Parameters of each light:
 struct osg_LightSourceParameters 
@@ -103,7 +103,10 @@ float oe_shadow_multisample(in vec3 c, in float refvalue, in float blur)
 
 void oe_shadow_fragment(inout vec4 color)
 {
-    float alpha = color.a;
+    oe_shadow_visibility = 1.0;
+#ifndef OE_LIGHTING
+    return;
+#endif
     float out_of_shadow = 1.0;
 
     // pre-pixel biasing to reduce moire/acne
@@ -112,7 +115,7 @@ void oe_shadow_fragment(inout vec4 color)
     vec3 L = normalize(osg_LightSource[0].position.xyz);
     vec3 N = normalize(vp_Normal);
     float costheta = clamp(dot(L,N), 0.0, 1.0);
-    float bias = b0*tan(acos(costheta));
+    float bias = min(b1, b0 * sqrt(max(1.0-costheta*costheta, 0.0)) / max(costheta, 0.01));
 
     float depth;
 
@@ -120,6 +123,8 @@ void oe_shadow_fragment(inout vec4 color)
     for(int i=0; i<$OE_SHADOW_NUM_SLICES && out_of_shadow > 0.0; ++i)
     {
         vec4 c = oe_shadow_coord[i];
+        if (any(lessThan(c.xyz, vec3(0.0))) || any(greaterThan(c.xyz, vec3(1.0))))
+            continue;
         vec3 coord = vec3(c.x, c.y, float(i));
 
         if ( oe_shadow_blur > 0.0 )
@@ -132,8 +137,9 @@ void oe_shadow_fragment(inout vec4 color)
             if ( depth < 1.0 && depth < c.z-bias )
                 out_of_shadow = 0.0;
         }
+        // The first containing cascade has the highest resolution.
+        break;
     }
 
-    oe_pbr.roughness = clamp(mix(oe_pbr.roughness*1.5, oe_pbr.roughness, out_of_shadow), 0, 1);
-    color.rgb = mix(color.rgb * oe_shadow_color, color.rgb, out_of_shadow);
+    oe_shadow_visibility = mix(clamp(oe_shadow_color, 0.0, 1.0), 1.0, out_of_shadow);
 }

--- a/src/osgEarth/Shadowing
+++ b/src/osgEarth/Shadowing
@@ -90,7 +90,8 @@ namespace osgEarth { namespace Util
         void setTextureSize(unsigned size);
 
         /**
-         * The ambient color level of the shadow. 0.0 = black. Default is 0.4
+         * Minimum direct-light visibility in shadow. Default is 0.0 (sunlight
+         * is fully blocked). Ambient and environment lighting are unaffected.
          */
         void setShadowColor(float value);
         float getShadowColor() const { return _color; }

--- a/src/osgEarth/Shadowing.cpp
+++ b/src/osgEarth/Shadowing.cpp
@@ -36,7 +36,7 @@ _enabled(true),
 _size         ( 4096 ),
 _texImageUnit ( 7 ),
 _blurFactor   ( 0.001f ),
-_color        ( 0.325f ),
+_color        ( 0.0f ),
 _traversalMask( ~0 )
 {
     _castingGroup = new osg::Group();
@@ -169,6 +169,7 @@ ShadowCaster::reinitialize()
     Shaders package;
     package.replace("$OE_SHADOW_NUM_SLICES", Stringify()<<numSlices);
     package.load(vp, package.ShadowCaster);
+    _renderStateSet->setDefine("OE_SHADOWING");
 
     // the texture coord generator matrix array (from the caster):
     _shadowMapTexGenUniform = _renderStateSet->getOrCreateUniform(

--- a/src/osgEarthDrivers/sky_gl/GLSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_gl/GLSkyNode.cpp
@@ -35,15 +35,10 @@ GLSkyNode::construct()
 
     _light = new LightGL3(0);
     _light->setDataVariance(_light->DYNAMIC);
-    _light->setAmbient(osg::Vec4(0.1f, 0.1f, 0.1f, 1.0f));
+    float ambient = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
+    _light->setAmbient(osg::Vec4(ambient, ambient, ambient, 1.0f));
     _light->setDiffuse(osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
     _light->setSpecular(osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
-
-    if ( _options.ambient().isSet() )
-    {
-        float a = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
-        _light->setAmbient(osg::Vec4(a, a, a, 1.0f));
-    }
 
     // installs the main uniforms and the shaders that will light the subgraph (terrain).
     osg::StateSet* stateset = this->getOrCreateStateSet();

--- a/src/osgEarthDrivers/sky_simple/BrunetonImpl.cpp
+++ b/src/osgEarthDrivers/sky_simple/BrunetonImpl.cpp
@@ -19,7 +19,7 @@ ComputeDrawable::ComputeDrawable(
     _bottom_radius(bottom_radius),
     _top_radius(top_radius),
 
-    _sun_angular_radius(0.01935f),
+    _sun_angular_radius(0.004675f), // Mean solar half-angle, about 0.268 degrees.
 
     // higher values make no visible difference
     _length_unit_in_meters(1.0f),
@@ -304,6 +304,8 @@ ComputeDrawable::populateRenderingStateSets(
 
         if (i == 0) // ground
         {
+            ss->setDefine("OE_SKY_REFLECTION_SAMPLES", _best_quality ? "16" : "8");
+
             std::string vert =
                 common +
                 (_best_quality ? shaders.ground_best_vert : shaders.ground_fast_vert);

--- a/src/osgEarthDrivers/sky_simple/CMakeLists.txt
+++ b/src/osgEarthDrivers/sky_simple/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 set(TARGET_GLSL
+    SimpleSky.Environment.glsl
     SimpleSky.Atmosphere.frag.glsl
     SimpleSky.Atmosphere.vert.glsl
     SimpleSky.Ground.ONeil.frag.glsl
@@ -29,6 +30,7 @@ configure_shaders(
     ${TARGET_GLSL} )
 
 set(TARGET_SRC
+    SkyEnvironment.cpp
     SimpleSkyExtension.cpp
     SimpleSkyNode.cpp
     BrunetonImpl.cpp
@@ -40,6 +42,7 @@ set(TARGET_SRC
     ${SHADERS_CPP} )
 
 set(TARGET_H
+    SkyEnvironment
     SimpleSkyOptions
 	SimpleSkyNode
     SimpleSkyShaders

--- a/src/osgEarthDrivers/sky_simple/SimpleSky.Environment.glsl
+++ b/src/osgEarthDrivers/sky_simple/SimpleSky.Environment.glsl
@@ -1,0 +1,46 @@
+#pragma vp_entryPoint oe_sky_environment_init
+#pragma vp_location fragment_lighting
+#pragma vp_order 0.75
+
+uniform samplerCube oe_sky_environmentTex;
+uniform sampler2D oe_sky_brdfTex;
+uniform vec3 oe_sky_irradiance[9];
+uniform float oe_sky_environmentMaxLOD;
+uniform mat4 osg_ViewMatrixInverse;
+
+// Reference radiance for the probe. Legacy ambient controls must not mute
+// the environment; oe_sky_iblStrength blends its contribution separately.
+const float oe_sky_environmentIntensity = 0.15;
+
+void oe_sky_environment_init(inout vec4 color) { }
+
+vec3 oe_sky_diffuseIrradiance(vec3 n)
+{
+    return max(vec3(0.0),
+        oe_sky_irradiance[0]*0.282095 +
+        oe_sky_irradiance[1]*(0.488603*n.y) +
+        oe_sky_irradiance[2]*(0.488603*n.z) +
+        oe_sky_irradiance[3]*(0.488603*n.x) +
+        oe_sky_irradiance[4]*(1.092548*n.x*n.y) +
+        oe_sky_irradiance[5]*(1.092548*n.y*n.z) +
+        oe_sky_irradiance[6]*(0.315392*(3.0*n.z*n.z-1.0)) +
+        oe_sky_irradiance[7]*(1.092548*n.x*n.z) +
+        oe_sky_irradiance[8]*(0.546274*(n.x*n.x-n.y*n.y)));
+}
+
+vec3 oe_sky_environment(vec3 N, vec3 V, vec3 albedo, float roughness, float metal, float ao)
+{
+    roughness=clamp(roughness,0.04,1.0);
+    metal=clamp(metal,0.0,1.0);
+    float nv=max(dot(N,V),0.0);
+    vec3 worldN=normalize(mat3(osg_ViewMatrixInverse)*N);
+    vec3 worldR=normalize(mat3(osg_ViewMatrixInverse)*reflect(-V,N));
+    vec3 f0=mix(vec3(0.04),albedo,metal);
+    vec3 fresnel=f0+(max(vec3(1.0-roughness),f0)-f0)*pow(1.0-nv,5.0);
+    vec3 kd=(1.0-fresnel)*(1.0-metal);
+    vec3 diffuse=kd*albedo*oe_sky_diffuseIrradiance(worldN);
+    vec2 brdf=texture(oe_sky_brdfTex,vec2(nv,roughness)).rg;
+    vec3 radiance=textureLod(oe_sky_environmentTex,worldR,roughness*oe_sky_environmentMaxLOD).rgb;
+    vec3 specular=radiance*(f0*brdf.x+brdf.y);
+    return (diffuse+specular)*clamp(ao,0.0,1.0)*oe_sky_environmentIntensity;
+}

--- a/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
+++ b/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
@@ -5,6 +5,17 @@
 #pragma import_defines(OE_LIGHTING)
 #pragma import_defines(OE_NUM_LIGHTS)
 #pragma import_defines(OE_USE_PBR)
+#pragma import_defines(OE_SHADOWING)
+#pragma import_defines(OE_SKY_ENVIRONMENT)
+
+#ifdef OE_SHADOWING
+float oe_shadow_visibility;
+#endif
+
+#ifdef OE_SKY_ENVIRONMENT
+uniform float oe_sky_iblStrength;
+vec3 oe_sky_environment(vec3 N, vec3 V, vec3 albedo, float roughness, float metal, float ao);
+#endif
 
 uniform float oe_sky_exposure = 3.3; // HDR scene exposure (ground level)
 uniform float oe_sky_ambientBoostFactor; // ambient sunlight booster for daytime (material mode only)
@@ -132,6 +143,7 @@ void atmos_fragment_main_pbr(inout vec4 color)
 
     vec3 Lo = vec3(0.0);
     vec3 ambientLight = vec3(0.0);
+    vec3 ambientMinimum = vec3(0.0);
     // Approximate the visible sky hemisphere independently of the sun direction.
     float skyVisibility = clamp(0.5 + 0.5 * dot(N, U), 0.0, 1.0);
 
@@ -170,11 +182,15 @@ void atmos_fragment_main_pbr(inout vec4 color)
 
         float sunElevation = dot(U, L);
         float sunVisibility = i == 0 ? atmos_sunVisibility(sunElevation) : 1.0;
+#ifdef OE_SHADOWING
+        if (i == 0) sunVisibility *= oe_shadow_visibility;
+#endif
 
         // Direct light uses the actual surface normal, including normal maps.
         Lo += (kD * albedo / PI + specular) * radiance * NdotL * sunVisibility;
 
         vec3 lightAmbient = osg_LightSource[i].ambient.rgb;
+        ambientMinimum += lightAmbient;
         if (i == 0)
         {
             // Keep the night-time minimum, and fade toward the daytime sky
@@ -187,6 +203,14 @@ void atmos_fragment_main_pbr(inout vec4 color)
     }
 
     vec3 ambient = clamp(ambientLight, 0.0, 1.0) * albedo * oe_pbr.ao;
+
+#ifdef OE_SKY_ENVIRONMENT
+    vec3 environment = oe_sky_environment(N, V, albedo,
+        oe_pbr.roughness, oe_pbr.metal, oe_pbr.ao);
+    if (!osg_LightSource[0].enabled) environment = vec3(0.0);
+    ambient = mix(ambient, clamp(ambientMinimum, 0.0, 1.0) * albedo * oe_pbr.ao + environment,
+        clamp(oe_sky_iblStrength, 0.0, 1.0));
+#endif
 
     color.rgb = ambient + Lo;
 
@@ -287,6 +311,9 @@ void atmos_fragment_material(inout vec4 color)
 
             // Apply the same horizon visibility to diffuse and specular sunlight.
             float sunVisibility = i == 0 ? atmos_sunVisibility(dayTerm) : 1.0;
+#ifdef OE_SHADOWING
+            if (i == 0) sunVisibility *= oe_shadow_visibility;
+#endif
 
             vec3 diffuseReflection =
                 attenuation

--- a/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
+++ b/src/osgEarthDrivers/sky_simple/SimpleSky.Ground.ONeil.frag.glsl
@@ -8,7 +8,7 @@
 
 uniform float oe_sky_exposure = 3.3; // HDR scene exposure (ground level)
 uniform float oe_sky_ambientBoostFactor; // ambient sunlight booster for daytime (material mode only)
-uniform float oe_sky_maxAmbientIntensity = 0.75; // maximum daytime ambient intensity (PBR mode only)
+uniform float oe_sky_maxAmbientIntensity = 0.15; // maximum daytime ambient intensity (PBR mode only)
 
 in vec3 atmos_lightDir;    // light direction (view coords)
 in vec3 atmos_color;       // atmospheric lighting color
@@ -105,8 +105,13 @@ vec3 atmos_safeNormalize(vec3 value, vec3 fallback)
     return length2 > 1e-12 ? value * inversesqrt(length2) : fallback;
 }
 
-const float oe_wrap = 0.22;
-uniform float oe_normal_boost = 1.0;
+float atmos_sunVisibility(float sunElevation)
+{
+    // Fade across the horizon (about 0.6 degrees on either side). Above it,
+    // let NdotL control direct sunlight instead of dimming every surface by
+    // the sun's elevation. Below it, prevent light from shining through Earth.
+    return smoothstep(-0.01, 0.01, sunElevation);
+}
 
 #ifdef OE_USE_PBR
 void atmos_fragment_main_pbr(inout vec4 color)
@@ -126,7 +131,9 @@ void atmos_fragment_main_pbr(inout vec4 color)
     F0 = mix(F0, albedo, vec3(oe_pbr.metal));
 
     vec3 Lo = vec3(0.0);
-    float ai = 0.0; // ambient intensity (based on time of day)
+    vec3 ambientLight = vec3(0.0);
+    // Approximate the visible sky hemisphere independently of the sun direction.
+    float skyVisibility = clamp(0.5 + 0.5 * dot(N, U), 0.0, 1.0);
 
     for (int i = 0; i < OE_NUM_LIGHTS; ++i)
     {
@@ -145,16 +152,12 @@ void atmos_fragment_main_pbr(inout vec4 color)
 
         float NdotL = max(dot(N, L), 0.0);
 
-        // wrap diffuse:
-        // https://developer.nvidia.com/gpugems/gpugems/part-iii-materials/chapter-16-real-time-approximations-subsurface-scattering
-        float NdotL_wrap = max(0.0, (NdotL + oe_wrap) / (1.0 + oe_wrap));
-
         float NdotV = max(0.0, dot(N, V));
 
         // cook-torrance BRDF:
         float roughness = clamp(oe_pbr.roughness, 0.0, 1.0);
         float NDF = DistributionGGX(N, H, roughness);
-        float G = GeometrySmith(NdotV, NdotL_wrap, roughness);
+        float G = GeometrySmith(NdotV, NdotL, roughness);
         vec3 F = FresnelSchlick(max(dot(H, V), 0.0), F0);
 
         vec3 kS = F;
@@ -162,20 +165,28 @@ void atmos_fragment_main_pbr(inout vec4 color)
         kD *= 1.0 - oe_pbr.metal;
 
         vec3 numerator = NDF * G * F;
-        float denominator = 4.0 * max(dot(N, V), 0.0) * NdotL_wrap;
+        float denominator = 4.0 * NdotV * NdotL;
         vec3 specular = NdotL > 0.0 ? numerator / max(denominator, 0.001) : vec3(0.0);
 
-        // daytime metric
-        float day = i == 0 ? max(0.0, dot(U, L)) : 1.0;
+        float sunElevation = dot(U, L);
+        float sunVisibility = i == 0 ? atmos_sunVisibility(sunElevation) : 1.0;
 
-        // color contribution
-        Lo += (kD * albedo / PI + specular) * radiance * NdotL_wrap * day;
+        // Direct light uses the actual surface normal, including normal maps.
+        Lo += (kD * albedo / PI + specular) * radiance * NdotL * sunVisibility;
 
-        // ambient intesntity contribution
-        ai = max(ai, NdotL_wrap * oe_sky_maxAmbientIntensity) * day;
+        vec3 lightAmbient = osg_LightSource[i].ambient.rgb;
+        if (i == 0)
+        {
+            // Keep the night-time minimum, and fade toward the daytime sky
+            // fill. Do not add another NdotL-based light on top of the BRDF.
+            vec3 skyAmbient = vec3(oe_sky_maxAmbientIntensity * skyVisibility);
+            lightAmbient = mix(lightAmbient, max(lightAmbient, skyAmbient),
+                clamp(sunElevation, 0.0, 1.0));
+        }
+        ambientLight += lightAmbient;
     }
 
-    vec3 ambient = clamp(osg_LightSource[0].ambient.rgb + vec3(ai), 0.0, 1.0) * albedo * oe_pbr.ao;
+    vec3 ambient = clamp(ambientLight, 0.0, 1.0) * albedo * oe_pbr.ao;
 
     color.rgb = ambient + Lo;
 
@@ -274,14 +285,12 @@ void atmos_fragment_material(inout vec4 color)
 
             float NdotL = max(dot(N,L), 0.0);
 
-            // this term, applied to light 0 (the sun), attenuates the diffuse light
-            // during the nighttime, so that geometry doesn't get lit based on its
-            // normals during the night.
-            float diffuseAttenuation = clamp(dayTerm+0.35, 0.0, 1.0);
+            // Apply the same horizon visibility to diffuse and specular sunlight.
+            float sunVisibility = i == 0 ? atmos_sunVisibility(dayTerm) : 1.0;
 
             vec3 diffuseReflection =
                 attenuation
-                * diffuseAttenuation
+                * sunVisibility
                 * osg_LightSource[i].diffuse.rgb
                 * NdotL;
 
@@ -298,6 +307,7 @@ void atmos_fragment_material(inout vec4 color)
                 specularReflection =
                       specAttenuation
                     * attenuation
+                    * sunVisibility
                     * osg_LightSource[i].specular.rgb
                     * surfaceSpecularity.rgb
                     * pow(HdotV, shine);

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode
@@ -4,6 +4,7 @@
  */
 
 #include "SimpleSkyOptions"
+#include "SkyEnvironment"
 #include <osgEarth/Sky>
 #include <osgEarth/MapNode>
 #include <osgEarth/PhongLightingEffect>
@@ -84,6 +85,8 @@ namespace osgEarth {
             osg::ref_ptr<osg::Uniform> _starPointSize;
 
             osg::ref_ptr<PhongLightingEffect> _phong;
+            osg::ref_ptr<SkyEnvironment> _environment;
+            osg::observer_ptr<osg::View> _environmentView;
 
             Ellipsoid _ellipsoid;
 

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -362,6 +362,32 @@ SimpleSkyNode::traverse(osg::NodeVisitor& nv)
 
     else if (nv.getVisitorType() == nv.UPDATE_VISITOR)
     {
+        if (_useONeil && _options.atmosphericLighting() == true &&
+            _options.environmentLighting() == true && _environmentView.valid())
+        {
+            if (!_environment.valid())
+            {
+                auto terrain = osgEarth::findTopMostNodeOfType<TerrainEngineNode>(this);
+                if (terrain)
+                {
+                    _environment = new SkyEnvironment;
+                    if (!_environment->attach(getOrCreateStateSet(), terrain->getResources()))
+                    {
+                        OE_WARN << LC << "No texture units available for sky environment lighting" << std::endl;
+                        _options.environmentLighting() = false;
+                        _environment = nullptr;
+                    }
+                }
+            }
+            if (_environment.valid())
+            {
+                const auto& p = _light->getPosition();
+                _environment->update(_environmentView.get(), osg::Vec3d(p.x(),p.y(),p.z()));
+                if (_environment->isReady())
+                    getOrCreateStateSet()->setDefine("OE_SKY_ENVIRONMENT");
+            }
+        }
+
         // If the Bruneton compute shaders are finished, set up the rendering statesets.
         if (_useBruneton &&
             !_eb_initialized &&
@@ -383,6 +409,9 @@ SimpleSkyNode::traverse(osg::NodeVisitor& nv)
                         terrain->getResources());
 
                     _eb_initialized = true;
+
+                    if (ok && groundStateSet && _options.environmentLighting() == true)
+                        groundStateSet->setDefine("OE_SKY_ENVIRONMENT");
 
                     if (!ok)
                     {
@@ -451,6 +480,7 @@ SimpleSkyNode::attach(osg::View* view, int lightNum)
         return;
 
     _light->setLightNum(lightNum);
+    _environmentView = view;
 
     // black background
     view->getCamera()->setClearColor(osg::Vec4(0, 0, 0, 1));
@@ -563,7 +593,8 @@ SimpleSkyNode::makeSceneLighting()
             //TODO: api
             stateset->getOrCreateUniform("atmos_haze_cutoff", osg::Uniform::FLOAT)->set(0.0f);
             stateset->getOrCreateUniform("atmos_haze_strength", osg::Uniform::FLOAT)->set(1.0f);
-            stateset->getOrCreateUniform("oe_sky_maxAmbientIntensity", osg::Uniform::FLOAT)->set(_options.maxAmbientIntensity().get());
+            if (_options.environmentLighting() == true)
+                stateset->getOrCreateUniform("oe_sky_groundReflectance", osg::Uniform::FLOAT)->set(_options.groundReflectance().get());
         }
         else if (_useONeil)
         {
@@ -590,6 +621,8 @@ SimpleSkyNode::makeSceneLighting()
 
     stateset->getOrCreateUniform("oe_sky_exposure", osg::Uniform::FLOAT)->set(
         _options.exposure().value());
+    if ((_useONeil || _useBruneton) && _options.atmosphericLighting() == true && _options.environmentLighting() == true)
+        stateset->getOrCreateUniform("oe_sky_iblStrength", osg::Uniform::FLOAT)->set(1.0f);
 }
 
 void

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -212,7 +212,8 @@ SimpleSkyNode::construct()
 
     _light = new LightGL3(0);
     _light->setPosition(osg::Vec4f(0.0f, 0.0f, 1.0f, 0.0f));
-    _light->setAmbient(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f));
+    float ambient = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
+    _light->setAmbient(osg::Vec4f(ambient, ambient, ambient, 1.0f));
     _light->setDiffuse(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f));
     _light->setSpecular(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)); // does nothing in PBR mode
 
@@ -222,12 +223,6 @@ SimpleSkyNode::construct()
     lightSource->setCullingActive(false);
     _cullContainer->addChild(lightSource);
     lightSource->addCullCallback(new LightSourceGL3UniformGenerator());
-
-    if (_options.ambient().isSet())
-    {
-        float a = osg::clampBetween(_options.ambient().get(), 0.0f, 1.0f);
-        _light->setAmbient(osg::Vec4(a, a, a, 1.0f));
-    }
 
     // only supports geocentric for now.
     if (getReferencePoint().isValid())

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
@@ -27,7 +27,7 @@ namespace osgEarth {
                 _allowWireframe(false),
                 _starSize(14.0f),
                 _moonScale(2.0f),
-                _maxAmbientIntensity(0.75f),
+                _maxAmbientIntensity(0.15f),
                 _moonImageURI("moon_1024x512.jpg"),
                 _sunVisible(true),
                 _moonVisible(true),
@@ -58,7 +58,7 @@ namespace osgEarth {
             optional<float>& daytimeAmbientBoost() { return _daytimeAmbientBoost; }
             const optional<float>& daytimeAmbientBoost() const { return _daytimeAmbientBoost; }
 
-            //! Maximum ambient value at high noon. Default=0.75
+            //! Maximum daytime ambient intensity. Default=0.15
             optional<float>& maxAmbientIntensity() { return _maxAmbientIntensity; }
             const optional<float>& maxAmbientIntensity() const { return _maxAmbientIntensity; }
 

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyOptions
@@ -22,6 +22,8 @@ namespace osgEarth {
             SimpleSkyOptions(const ConfigOptions& options = ConfigOptions()) :
                 SkyOptions(options),
                 _atmosphericLighting(true),
+                _environmentLighting(true),
+                _groundReflectance(0.15f),
                 _exposure(3.3f),
                 _daytimeAmbientBoost(5.0f),
                 _allowWireframe(false),
@@ -46,6 +48,14 @@ namespace osgEarth {
             /** Use advanced atmospheric lighting on the terrain (instead of simple shading) */
             optional<bool>& atmosphericLighting() { return _atmosphericLighting; }
             const optional<bool>& atmosphericLighting() const { return _atmosphericLighting; }
+
+            //! Add diffuse and specular sky environment lighting.
+            optional<bool>& environmentLighting() { return _environmentLighting; }
+            const optional<bool>& environmentLighting() const { return _environmentLighting; }
+
+            //! Mean ground reflectance for Bruneton indirect lighting; linear [0,1].
+            optional<float>& groundReflectance() { return _groundReflectance; }
+            const optional<float>& groundReflectance() const { return _groundReflectance; }
 
             /** Exposure factor for simulated HDR ground lighting. Default is in CTOR */
             optional<float>& exposure() { return _exposure; }
@@ -113,6 +123,8 @@ namespace osgEarth {
             Config getConfig() const {
                 Config conf = SkyOptions::getConfig();
                 conf.set("atmospheric_lighting", _atmosphericLighting);
+                conf.set("environment_lighting", _environmentLighting);
+                conf.set("ground_reflectance", _groundReflectance);
                 conf.set("exposure", _exposure);
                 conf.set("daytime_ambient_boost", _daytimeAmbientBoost);
                 conf.set("max_ambient_intensity", _maxAmbientIntensity);
@@ -140,6 +152,8 @@ namespace osgEarth {
         private:
             void fromConfig(const Config& conf) {
                 conf.get("atmospheric_lighting", _atmosphericLighting);
+                conf.get("environment_lighting", _environmentLighting);
+                conf.get("ground_reflectance", _groundReflectance);
                 conf.get("exposure", _exposure);
                 conf.get("daytime_ambient_boost", _daytimeAmbientBoost);
                 conf.get("max_ambient_intensity", _maxAmbientIntensity);
@@ -158,6 +172,8 @@ namespace osgEarth {
             }
 
             optional<bool>        _atmosphericLighting;
+            optional<bool>        _environmentLighting;
+            optional<float>       _groundReflectance;
             optional<float>       _exposure;
             optional<float>       _daytimeAmbientBoost;
             optional<float>       _maxAmbientIntensity;

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyShaders
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyShaders
@@ -12,6 +12,7 @@ namespace osgEarth { namespace SimpleSky
     struct Shaders : public osgEarth::Util::ShaderPackage
 	{
         Shaders();
+        std::string Environment;
 		std::string Atmosphere_Vert;
 		std::string Atmosphere_Frag;
         std::string Ground_ONeil_Vert;

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyShaders.cpp.in
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyShaders.cpp.in
@@ -7,6 +7,8 @@ using namespace osgEarth::SimpleSky;
 
 Shaders::Shaders()
 {
+    Environment = "SimpleSky.Environment.glsl";
+    _sources[Environment] = @SimpleSky.Environment.glsl@;
     Atmosphere_Vert = "SimpleSky.Atmosphere.vert.glsl";
     _sources[Atmosphere_Vert] = @SimpleSky.Atmosphere.vert.glsl@;
 

--- a/src/osgEarthDrivers/sky_simple/SkyEnvironment
+++ b/src/osgEarthDrivers/sky_simple/SkyEnvironment
@@ -1,0 +1,35 @@
+/* osgEarth
+ * Copyright 2026 Pelican Mapping
+ * MIT License
+ */
+#pragma once
+
+#include <osgEarth/TerrainResources>
+#include <osg/TextureCubeMap>
+#include <osg/Texture2D>
+#include <osg/View>
+#include <osg/Uniform>
+#include <chrono>
+
+namespace osgEarth { namespace SimpleSky {
+
+// A local, procedural sky probe. It contains sky and ground radiance, not
+// reflected scene geometry. All images and coefficients are in linear space.
+class SkyEnvironment : public osg::Referenced
+{
+public:
+    bool attach(osg::StateSet* stateset, TerrainResources* resources);
+    void update(osg::View* view, const osg::Vec3d& sunDirection);
+    bool isReady() const { return _initialized; }
+
+private:
+    TextureImageUnitReservation _environmentUnit, _brdfUnit;
+    osg::ref_ptr<osg::TextureCubeMap> _environment;
+    osg::ref_ptr<osg::Texture2D> _brdf;
+    osg::ref_ptr<osg::Uniform> _irradiance;
+    osg::Vec3d _lastUp, _lastSun;
+    bool _initialized = false;
+    std::chrono::steady_clock::time_point _lastUpdate;
+};
+
+} }

--- a/src/osgEarthDrivers/sky_simple/SkyEnvironment.cpp
+++ b/src/osgEarthDrivers/sky_simple/SkyEnvironment.cpp
@@ -1,0 +1,242 @@
+/* osgEarth
+ * Copyright 2026 Pelican Mapping
+ * MIT License
+ */
+#include "SkyEnvironment"
+#include "SimpleSkyShaders"
+#include <osgEarth/VirtualProgram>
+#include <osgEarth/Capabilities>
+#include <osgEarth/Registry>
+#include <osg/Camera>
+#include <osg/GLDefines>
+#include <cmath>
+#include <cstdint>
+
+using namespace osgEarth;
+using namespace osgEarth::SimpleSky;
+
+namespace
+{
+    constexpr float PI = 3.14159265359f;
+    constexpr unsigned SIZE = 32, LEVELS = 6, SAMPLES = 64;
+
+    float saturate(float x) { return osg::clampBetween(x, 0.0f, 1.0f); }
+    float smooth(float a, float b, float x)
+    {
+        float t = saturate((x-a)/(b-a));
+        return t*t*(3.0f-2.0f*t);
+    }
+    osg::Vec3 mix(const osg::Vec3& a, const osg::Vec3& b, float t) { return a*(1-t)+b*t; }
+
+    float radicalInverse(uint32_t bits)
+    {
+        bits = (bits << 16u) | (bits >> 16u);
+        bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+        bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+        bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+        bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+        return float(bits) * 2.3283064365386963e-10f;
+    }
+
+    osg::Vec3 sampleGGX(unsigned i, float roughness, const osg::Vec3& n)
+    {
+        float phi = 2.0f*PI*float(i)/SAMPLES;
+        float y = radicalInverse(i);
+        float a = roughness*roughness;
+        float z = std::sqrt((1.0f-y)/(1.0f+(a*a-1.0f)*y));
+        float r = std::sqrt(std::max(0.0f, 1.0f-z*z));
+        osg::Vec3 axis = std::abs(n.z()) < 0.999f ? osg::Vec3(0,0,1) : osg::Vec3(1,0,0);
+        osg::Vec3 t = axis ^ n;
+        t.normalize();
+        osg::Vec3 b = n ^ t;
+        return t*(r*std::cos(phi)) + b*(r*std::sin(phi)) + n*z;
+    }
+
+    osg::Vec3 cubeDirection(unsigned face, float u, float v)
+    {
+        osg::Vec3 d;
+        switch (face)
+        {
+        case 0: d.set(1,-v,-u); break;
+        case 1: d.set(-1,-v,u); break;
+        case 2: d.set(u,1,v); break;
+        case 3: d.set(u,-1,-v); break;
+        case 4: d.set(u,-v,1); break;
+        default: d.set(-u,-v,-1); break;
+        }
+        d.normalize();
+        return d;
+    }
+
+    // Clear-sky approximation with a broad scattering halo. The solar disk
+    // is deliberately absent: its energy comes from the direct sun light.
+    osg::Vec3 skyRadiance(const osg::Vec3& d, const osg::Vec3& up, const osg::Vec3& sun)
+    {
+        float sunHeight = up*sun;
+        float day = smooth(-0.12f, 0.15f, sunHeight);
+        float noon = smooth(0.0f, 0.4f, sunHeight);
+        float altitude = d*up;
+        osg::Vec3 horizon = mix(osg::Vec3(1.1f,0.38f,0.12f), osg::Vec3(0.8f,0.88f,1.0f), noon);
+        osg::Vec3 zenith = mix(osg::Vec3(0.12f,0.16f,0.30f), osg::Vec3(0.16f,0.36f,0.80f), noon);
+        osg::Vec3 sky = mix(horizon, zenith, std::pow(std::max(altitude,0.0f),0.45f));
+        sky += mix(osg::Vec3(1.0f,0.35f,0.1f),osg::Vec3(1.0f,0.9f,0.7f),noon) *
+            (0.2f*std::pow(std::max(d*sun,0.0f),16.0f));
+        osg::Vec3 ground(0.12f,0.10f,0.075f);
+        return mix(ground,sky,smooth(-0.05f,0.03f,altitude))*day;
+    }
+
+    void basis(const osg::Vec3& n, float* b)
+    {
+        b[0]=0.282095f;
+        b[1]=0.488603f*n.y(); b[2]=0.488603f*n.z(); b[3]=0.488603f*n.x();
+        b[4]=1.092548f*n.x()*n.y(); b[5]=1.092548f*n.y()*n.z();
+        b[6]=0.315392f*(3*n.z()*n.z()-1);
+        b[7]=1.092548f*n.x()*n.z(); b[8]=0.546274f*(n.x()*n.x()-n.y()*n.y());
+    }
+
+    osg::Texture2D* makeBRDF()
+    {
+        // Split-sum environment BRDF, indexed by NdotV and perceptual roughness.
+        osg::ref_ptr<osg::Image> image = new osg::Image;
+        constexpr unsigned size = 64;
+        image->allocateImage(size,size,1,GL_RG,GL_FLOAT);
+        for (unsigned y=0; y<size; ++y)
+        for (unsigned x=0; x<size; ++x)
+        {
+            float roughness=(y+0.5f)/size, nv=(x+0.5f)/size;
+            osg::Vec3 v(std::sqrt(1-nv*nv),0,nv), n(0,0,1);
+            float a=0, b=0, k=roughness*roughness*0.5f;
+            for (unsigned i=0; i<SAMPLES; ++i)
+            {
+                osg::Vec3 h=sampleGGX(i,roughness,n);
+                float vh=std::max(v*h,0.0f);
+                osg::Vec3 l=h*(2*vh)-v;
+                float nl=std::max(l.z(),0.0f), nh=std::max(h.z(),0.0f);
+                if (nl>0 && nh>0)
+                {
+                    float g=(nv/(nv*(1-k)+k))*(nl/(nl*(1-k)+k));
+                    float visibility=g*vh/std::max(nh*nv,1e-6f);
+                    float fresnel=std::pow(1-vh,5.0f);
+                    a+=(1-fresnel)*visibility; b+=fresnel*visibility;
+                }
+            }
+            float* pixel=reinterpret_cast<float*>(image->data(x,y));
+            pixel[0]=a/SAMPLES; pixel[1]=b/SAMPLES;
+        }
+        auto texture=new osg::Texture2D(image);
+        texture->setInternalFormat(GL_RG16F);
+        texture->setFilter(osg::Texture::MIN_FILTER,osg::Texture::LINEAR);
+        texture->setFilter(osg::Texture::MAG_FILTER,osg::Texture::LINEAR);
+        texture->setWrap(osg::Texture::WRAP_S,osg::Texture::CLAMP_TO_EDGE);
+        texture->setWrap(osg::Texture::WRAP_T,osg::Texture::CLAMP_TO_EDGE);
+        return texture;
+    }
+}
+
+bool SkyEnvironment::attach(osg::StateSet* ss, TerrainResources* resources)
+{
+    if (!resources->reserveTextureImageUnit(_environmentUnit,"Sky environment") ||
+        !resources->reserveTextureImageUnit(_brdfUnit,"Sky environment BRDF"))
+    {
+        _environmentUnit.release(); _brdfUnit.release();
+        return false;
+    }
+    _environment=new osg::TextureCubeMap;
+    _environment->setInternalFormat(GL_RGB16F_ARB);
+    _environment->setFilter(osg::Texture::MIN_FILTER,osg::Texture::LINEAR_MIPMAP_LINEAR);
+    _environment->setFilter(osg::Texture::MAG_FILTER,osg::Texture::LINEAR);
+    for (auto wrap : {osg::Texture::WRAP_S,osg::Texture::WRAP_T,osg::Texture::WRAP_R})
+        _environment->setWrap(wrap,osg::Texture::CLAMP_TO_EDGE);
+    _environment->setUseHardwareMipMapGeneration(false);
+    // Interpolate across cube faces, including the coarsest roughness mips.
+    // GLES already requires seamless cube filtering and has no enable token.
+    const auto& caps = Registry::capabilities();
+    if (!caps.isGLES() && caps.getGLSLVersion() >= 1.50f)
+        ss->setMode(GL_TEXTURE_CUBE_MAP_SEAMLESS, osg::StateAttribute::ON);
+    _brdf=makeBRDF();
+    _irradiance=new osg::Uniform(osg::Uniform::FLOAT_VEC3,"oe_sky_irradiance",9);
+    ss->setTextureAttributeAndModes(_environmentUnit.unit(),_environment,osg::StateAttribute::ON);
+    ss->setTextureAttributeAndModes(_brdfUnit.unit(),_brdf,osg::StateAttribute::ON);
+    ss->addUniform(new osg::Uniform("oe_sky_environmentTex",_environmentUnit.unit()));
+    ss->addUniform(new osg::Uniform("oe_sky_brdfTex",_brdfUnit.unit()));
+    ss->addUniform(new osg::Uniform("oe_sky_environmentMaxLOD",float(LEVELS-1)));
+    ss->addUniform(_irradiance);
+    Shaders shaders;
+    shaders.load(VirtualProgram::getOrCreate(ss),shaders.Environment);
+    // The define is installed only after the initial probe has been generated.
+    return true;
+}
+
+void SkyEnvironment::update(osg::View* view, const osg::Vec3d& sunDirection)
+{
+    if (!view || !_environment.valid()) return;
+    osg::Vec3d up=view->getCamera()->getInverseViewMatrix().getTrans();
+    if (up.length2()<1.0 || sunDirection.length2()<1e-12) return;
+    up.normalize();
+    osg::Vec3d sun=sunDirection; sun.normalize();
+    auto now=std::chrono::steady_clock::now();
+    if (_initialized && ((_lastUp-up).length2()<4e-6 && (_lastSun-sun).length2()<4e-6)) return;
+    if (_initialized && now-_lastUpdate<std::chrono::milliseconds(250)) return;
+    _lastUp=up; _lastSun=sun; _lastUpdate=now;
+
+    osg::Vec3 u(up), s(sun), coefficients[9];
+    constexpr unsigned sphereSamples=2048;
+    for (unsigned i=0; i<sphereSamples; ++i)
+    {
+        float z=1-2*(i+0.5f)/sphereSamples, phi=i*2.3999632297f;
+        float r=std::sqrt(1-z*z);
+        osg::Vec3 d(r*std::cos(phi),r*std::sin(phi),z);
+        float b[9]; basis(d,b);
+        osg::Vec3 radiance=skyRadiance(d,u,s);
+        for (unsigned j=0; j<9; ++j)
+            coefficients[j]+=radiance*(b[j]*(4*PI/sphereSamples));
+    }
+    for (unsigned j=0; j<9; ++j)
+    {
+        // Cosine convolution divided by PI for Lambertian diffuse.
+        float convolution=j==0 ? 1.0f : j<4 ? 2.0f/3.0f : 0.25f;
+        _irradiance->setElement(j,coefficients[j]*convolution);
+    }
+
+    for (unsigned face=0; face<6; ++face)
+    {
+        osg::Image::MipmapDataType offsets;
+        unsigned count=0;
+        for (unsigned level=0; level<LEVELS; ++level)
+        {
+            if (level) offsets.push_back(count*sizeof(float));
+            unsigned size=SIZE>>level; count+=size*size*3;
+        }
+        auto bytes=new unsigned char[count*sizeof(float)];
+        float* pixel=reinterpret_cast<float*>(bytes);
+        for (unsigned level=0; level<LEVELS; ++level)
+        {
+            unsigned size=SIZE>>level;
+            float roughness=float(level)/(LEVELS-1);
+            for (unsigned y=0; y<size; ++y)
+            for (unsigned x=0; x<size; ++x)
+            {
+                osg::Vec3 n=cubeDirection(face,2*(x+0.5f)/size-1,2*(y+0.5f)/size-1);
+                osg::Vec3 color;
+                float weight=0;
+                if (level==0) color=skyRadiance(n,u,s);
+                else
+                {
+                    for (unsigned i=0; i<SAMPLES; ++i)
+                    {
+                        osg::Vec3 h=sampleGGX(i,roughness,n), l=h*(2*(n*h))-n;
+                        float nl=std::max(n*l,0.0f);
+                        color+=skyRadiance(l,u,s)*nl; weight+=nl;
+                    }
+                    color/=std::max(weight,1e-6f);
+                }
+                *pixel++=color.x(); *pixel++=color.y(); *pixel++=color.z();
+            }
+        }
+        osg::ref_ptr<osg::Image> image=new osg::Image;
+        image->setImage(SIZE,SIZE,1,GL_RGB16F_ARB,GL_RGB,GL_FLOAT,bytes,osg::Image::USE_NEW_DELETE);
+        image->setMipmapLevels(offsets);
+        _environment->setImage(face,image);
+    }
+    _initialized=true;
+}

--- a/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
+++ b/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
@@ -10,7 +10,7 @@ header = R"(
 
 pbr = R"(
 
-uniform float oe_sky_maxAmbientIntensity = 0.75;
+uniform float oe_sky_maxAmbientIntensity = 0.15;
 
 // https://learnopengl.com/PBR/Lighting
 
@@ -174,7 +174,7 @@ in vec3 atmos_ambient;
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
 {    
 #ifdef OE_LIGHTING
-    vec3 N = vp_Normal; //gl_FrontFacing ? vp_Normal : -vp_Normal;
+    vec3 N = normalize(vp_Normal);
 	vec3 sky_irradiance;
 	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
 	vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);
@@ -294,7 +294,7 @@ const vec3 white_point = vec3(1,1,1);
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
 {
 #ifdef OE_LIGHTING
-    vec3 N = vp_Normal; //gl_FrontFacing ? vp_Normal : -vp_Normal;
+    vec3 N = normalize(vp_Normal);
 	vec3 sky_irradiance;
 	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
     vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);

--- a/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
+++ b/src/osgEarthDrivers/sky_simple/eb_osgearth_shaders.cpp
@@ -9,97 +9,195 @@ header = R"(
 
 
 pbr = R"(
+#pragma import_defines(OE_USE_PBR)
+#pragma import_defines(OE_SHADOWING)
+#pragma import_defines(OE_SKY_ENVIRONMENT)
+#pragma import_defines(OE_SKY_REFLECTION_SAMPLES)
 
-uniform float oe_sky_maxAmbientIntensity = 0.15;
-
-// https://learnopengl.com/PBR/Lighting
-
-//const float PI = 3.14159265359;
-
-float DistributionGGX(vec3 N, vec3 H, float roughness)
-{
-    float a = roughness * roughness;
-    float a2 = a * a;
-    float NdotH = max(dot(N, H), 0.0);
-    float NdotH2 = NdotH * NdotH;
-
-    float num = a2;
-    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
-    denom = PI * denom * denom;
-
-    return num / denom;
-}
-
-float GeometrySchlickGGX(float NdotV, float roughness)
-{
-    float r = (roughness + 1.0);
-    float k = (r*r) / 8.0;
-
-    float nom = NdotV;
-    float denom = NdotV * (1.0 - k) + k;
-
-    return nom / denom;
-}
-
-float GeometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
-{
-    float NdotV = max(dot(N, V), 0.0);
-    float NdotL = max(dot(N, L), 0.0);
-    float ggx2 = GeometrySchlickGGX(NdotV, roughness);
-    float ggx1 = GeometrySchlickGGX(NdotL, roughness);
-
-    return ggx1 * ggx2;
-}
-
-vec3 FresnelSchlick(float cosTheta, vec3 F0)
-{
-    return F0 + (1.0 - F0) * pow(max(1.0 - cosTheta, 0.0), 5.0);
-}
-
+#ifdef OE_SHADOWING
+float oe_shadow_visibility;
+#endif
 #ifdef OE_USE_PBR
-// fragment stage global PBR params
 struct OE_PBR { float displacement, roughness, ao, metal; } oe_pbr;
+#endif
 
-void atmos_pbr_spec(in vec3 vertex_dir, in vec3 vert_to_light, in vec3 N, inout vec3 ambience, inout vec3 COLOR)
+uniform float oe_sky_iblStrength = 1.0;
+uniform float oe_sky_groundReflectance = 0.15;
+uniform float oe_sky_exposure;
+uniform mat4 osg_ViewMatrix;
+
+vec3 atmos_normalize(vec3 v, vec3 fallback)
 {
-    // PBR (https://learnopengl.com/PBR/Lighting)
-    vec3 V = -vertex_dir;
-    vec3 L = normalize(vert_to_light);
-    vec3 H = normalize(V + L);
+    float len2 = dot(v, v);
+    return len2 > 1e-12 ? v * inversesqrt(len2) : fallback;
+}
 
-    vec3 albedo = COLOR;
-    vec3 F0 = vec3(0.04);
-    F0 = mix(F0, albedo, vec3(oe_pbr.metal));
+vec3 atmos_decode(vec3 c)
+{
+    c = max(c, vec3(0.0));
+    return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)),
+        greaterThan(c, vec3(0.04045)));
+}
 
-    // cook-torrance BRDF:
-    float NDF = DistributionGGX(N, H, oe_pbr.roughness);
-    float G = GeometrySmith(N, V, L, oe_pbr.roughness);
-    vec3 F = FresnelSchlick(max(dot(H, V), 0.0), F0);
+vec3 atmos_encode(vec3 c)
+{
+    c = max(c, vec3(0.0));
+    return mix(12.92 * c, 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055,
+        greaterThan(c, vec3(0.0031308)));
+}
 
-    vec3 kS = F;
-    vec3 kD = vec3(1.0) - kS;
-    kD *= 1.0 - oe_pbr.metal;
+vec3 atmos_fresnel(float vh, vec3 f0)
+{
+    return f0 + (1.0 - f0) * pow(1.0 - clamp(vh, 0.0, 1.0), 5.0);
+}
 
-    float NdotL = max(dot(N, L), 0.0);
-    vec3 numerator = NDF * G * F;
-    float denominator = 4.0 * max(dot(N, V), 0.0) * NdotL;
-    vec3 specular = numerator / max(denominator, 0.001);
+float atmos_G1(float nx, float alpha2)
+{
+    return 2.0 * nx / max(nx + sqrt(alpha2 + (1.0 - alpha2) * nx * nx), 1e-6);
+}
 
-    //ambience *= oe_pbr.ao;
+vec3 atmos_directBRDF(vec3 N, vec3 V, vec3 L, vec3 albedo, vec3 f0,
+    float metal, float alpha2)
+{
+    float nv = max(dot(N, V), 1e-4), nl = max(dot(N, L), 0.0);
+    if (nl <= 0.0) return vec3(0.0);
+    vec3 H = atmos_normalize(V + L, N);
+    float nh = max(dot(N, H), 0.0);
+    float d = nh * nh * (alpha2 - 1.0) + 1.0;
+    float distribution = alpha2 / max(PI * d * d, 1e-12);
+    vec3 F = atmos_fresnel(dot(V, H), f0);
+    vec3 specular = distribution * atmos_G1(nv, alpha2) * atmos_G1(nl, alpha2) * F /
+        max(4.0 * nv * nl, 1e-6);
+    // GetSunAndSkyIrradiance already includes NdotL; do not multiply it again.
+    return (1.0 - F) * (1.0 - metal) * albedo / PI + specular;
+}
 
-    // ONLY calcuate the specularity here since we are incoporating
-    // the radiance, etc. elsewhere.
-    vec3 Lo = (kD * albedo + specular*NdotL);
+#ifdef OE_SKY_ENVIRONMENT
+// Heitz 2018 GGX visible-normal sampling. With separable Smith masking the
+// importance weight reduces to Fresnel * G1(NdotL), bounded even at grazing angles.
+// https://jcgt.org/published/0007/04/01/
+vec3 atmos_sampleVisibleGGX(vec3 view, float alpha, vec2 xi)
+{
+    vec3 stretched = normalize(vec3(alpha * view.xy, max(view.z, 1e-4)));
+    float lensq = dot(stretched.xy, stretched.xy);
+    vec3 t1 = lensq > 1e-8 ? vec3(-stretched.y, stretched.x, 0.0) / sqrt(lensq) : vec3(1, 0, 0);
+    vec3 t2 = cross(stretched, t1);
+    float r = sqrt(xi.x), phi = 2.0 * PI * xi.y;
+    float x = r * cos(phi), y = r * sin(phi);
+    float blend = 0.5 * (1.0 + stretched.z);
+    y = mix(sqrt(max(1.0 - x * x, 0.0)), y, blend);
+    vec3 h = x * t1 + y * t2 + sqrt(max(1.0 - x * x - y * y, 0.0)) * stretched;
+    return normalize(vec3(alpha * h.xy, max(h.z, 0.0)));
+}
 
-    // Original equation for reference
-    //vec3 Lo = (kD * albedo / PI + specular) * radiance * NdotL;
-    
-    // ambient intensity based on time of day
-    ambience = clamp(ambience + vec3(oe_sky_maxAmbientIntensity*NdotL), 0.0, 1.0);
+vec3 atmos_environmentRadiance(vec3 point, vec3 direction, vec3 sun,
+    vec3 groundRadiance)
+{
+    float radius = length(point);
+    float mu = dot(point, direction) / radius;
+    // The atmosphere LUT excludes surface reflection. Supply a neutral mean
+    // ground radiance for rays hitting Earth; no fabricated building reflections.
+    if (RayIntersectsGround(radius, mu))
+        return groundRadiance;
+    vec3 transmittance;
+    return max(GetSkyRadiance(point, direction, 0.0, sun, transmittance), vec3(0.0));
+}
 
-    COLOR = Lo * oe_pbr.ao;
+vec3 atmos_environmentSpecular(vec3 point, vec3 N, vec3 V, vec3 sun, vec3 f0,
+    float alpha, vec3 groundRadiance, out vec3 reflectedEnergy)
+{
+    // Anchor the sampling frame in world space so orbiting the camera does not
+    // rotate an arbitrary sample pattern around the normal.
+    vec3 axis = osg_ViewMatrix[2].xyz;
+    if (abs(dot(axis, N)) > 0.99) axis = osg_ViewMatrix[0].xyz;
+    vec3 T = normalize(cross(axis, N)), B = cross(N, T);
+    vec3 localV = vec3(dot(V, T), dot(V, B), max(dot(V, N), 1e-4));
+    vec3 result = vec3(0.0);
+    reflectedEnergy = vec3(0.0);
+    for (int i = 0; i < OE_SKY_REFLECTION_SAMPLES; ++i)
+    {
+        vec2 xi = vec2((float(i) + 0.5) / float(OE_SKY_REFLECTION_SAMPLES),
+            float(bitfieldReverse(uint(i))) * 2.3283064365386963e-10);
+        vec3 h = atmos_sampleVisibleGGX(localV, alpha, xi);
+        vec3 H = T * h.x + B * h.y + N * h.z;
+        float vh = max(dot(V, H), 0.0);
+        vec3 L = 2.0 * vh * H - V;
+        float nl = max(dot(N, L), 0.0);
+        if (nl > 0.0)
+        {
+            vec3 weight = atmos_fresnel(vh, f0) * atmos_G1(nl, alpha * alpha);
+            result += atmos_environmentRadiance(point, L, sun, groundRadiance) * weight;
+            reflectedEnergy += weight;
+        }
+    }
+    reflectedEnergy /= float(OE_SKY_REFLECTION_SAMPLES);
+    return result / float(OE_SKY_REFLECTION_SAMPLES);
 }
 #endif
+
+vec3 atmos_surfaceRadiance(vec3 displayColor, vec3 point, vec3 N, vec3 V,
+    vec3 L, vec3 ambient, vec3 sunColor, float sunEnabled)
+{
+    vec3 albedo = atmos_decode(displayColor);
+    float roughness = 1.0, metal = 0.0, ao = 1.0;
+#ifdef OE_USE_PBR
+    roughness = clamp(oe_pbr.roughness, 0.045, 1.0);
+    metal = clamp(oe_pbr.metal, 0.0, 1.0);
+    ao = clamp(oe_pbr.ao, 0.0, 1.0);
+#endif
+    // Filter sub-pixel normal variance into the specular lobe to limit sparkle.
+    vec3 dx = dFdx(N), dy = dFdy(N);
+    float variance = 0.5 * (dot(dx, dx) + dot(dy, dy));
+    float alpha2 = clamp(pow(roughness, 4.0) + min(variance, 0.25), 4e-6, 1.0);
+    float alpha = sqrt(alpha2);
+    vec3 f0 = mix(vec3(0.04), albedo, metal);
+    vec3 U = atmos_normalize(point, N);
+    // Avoid invalid LUT coordinates for geometry slightly below the ellipsoid.
+    point = U * max(length(point), bottom_radius + UNIT_LENGTH_METERS_INVERSE);
+    vec3 skyIrradiance;
+    vec3 sunIrradiance = GetSunAndSkyIrradiance(point, N, L, skyIrradiance);
+    float sunlightVisibility = sunEnabled;
+#ifdef OE_SHADOWING
+    sunlightVisibility *= oe_shadow_visibility;
+#endif
+    // Approximate the finite solar disk in the direct specular lobe, without
+    // broadening reflections of the rest of the environment.
+    float sunAlpha2 = min(alpha2 + 0.25 * sun_angular_radius * sun_angular_radius, 1.0);
+    vec3 direct = atmos_directBRDF(N, V, L, albedo, f0, metal, sunAlpha2) *
+        max(sunIrradiance, vec3(0.0)) * sunColor * sunlightVisibility;
+
+    vec3 indirect = vec3(0.0);
+#ifdef OE_SKY_ENVIRONMENT
+    float environmentStrength = clamp(oe_sky_iblStrength, 0.0, 1.0) * sunEnabled;
+    if (environmentStrength > 0.0)
+    {
+        vec3 skyUp;
+        vec3 sunUp = GetSunAndSkyIrradiance(point, U, L, skyUp);
+        vec3 groundRadiance = clamp(oe_sky_groundReflectance, 0.0, 1.0) *
+            max(sunUp + skyUp, vec3(0.0)) / PI;
+        vec3 groundIrradiance = groundRadiance * PI * clamp(0.5 - 0.5 * dot(N, U), 0.0, 1.0);
+        vec3 reflectedEnergy;
+        vec3 specular = atmos_environmentSpecular(point, N, V, L, f0, alpha,
+            groundRadiance, reflectedEnergy);
+        // Share the indirect energy budget between diffuse and specular. A
+        // rough dielectric must not lose all diffuse light at grazing angles.
+        vec3 kd = (1.0 - clamp(reflectedEnergy, 0.0, 1.0)) * (1.0 - metal);
+        vec3 diffuse = kd * albedo * max(skyIrradiance + groundIrradiance, vec3(0.0)) / PI;
+        // AO describes local indirect-light visibility, not sunlight intensity.
+        indirect = (diffuse + specular) * ao * environmentStrength;
+    }
+#endif
+    // Retain an optional night-time fill in linear space. Never impose a
+    // sun-facing brightness floor after tone mapping, or let it bypass shadows.
+    indirect += (1.0 - metal) * albedo * atmos_decode(ambient) * (1e5 / PI) * ao;
+    return direct + indirect;
+}
+
+vec3 atmos_finish(vec3 surface, vec3 transmittance, vec3 scatter)
+{
+    vec3 radiance = max(surface * transmittance + scatter, vec3(0.0));
+    return atmos_encode(1.0 - exp(-radiance * max(oe_sky_exposure, 0.0) * 1e-5));
+}
 )";
 
 ground_best_vert = R"(
@@ -133,8 +231,9 @@ out vec3 atmos_view_dir;
 out vec3 atmos_light_dir;
 out vec3 atmos_center_to_camera;
 out vec3 atmos_center_to_vert;
-out vec3 atmos_vert_to_light;
 out vec3 atmos_ambient;
+out vec3 atmos_sun_color;
+flat out float atmos_sun_enabled;
 
 void atmos_eb_ground_render_vert(inout vec4 vertex_view)
 {
@@ -143,11 +242,12 @@ void atmos_eb_ground_render_vert(inout vec4 vertex_view)
     vec3 earth_center = temp.xyz/temp.w;
     atmos_light_dir = normalize(osg_LightSource[0].position.xyz);  // view space
     atmos_ambient = osg_LightSource[0].ambient.rgb;
+    atmos_sun_color = osg_LightSource[0].diffuse.rgb;
+    atmos_sun_enabled = osg_LightSource[0].enabled ? 1.0 : 0.0;
     const vec3 camera_pos = vec3(0,0,0);
     atmos_center_to_camera = (camera_pos - earth_center) * UNIT_LENGTH_METERS_INVERSE;
     atmos_center_to_vert = (vertex_view.xyz - earth_center) * UNIT_LENGTH_METERS_INVERSE;
-    atmos_view_dir = normalize(vertex_view.xyz);
-    atmos_vert_to_light = (osg_LightSource[0].position.xyz - vertex_view.xyz);
+    atmos_view_dir = vertex_view.xyz;
 #endif
 }
 
@@ -156,54 +256,33 @@ void atmos_eb_ground_render_vert(inout vec4 vertex_view)
 
 ground_best_frag = R"(
 #pragma import_defines(OE_LIGHTING)
-#pragma import_defines(OE_USE_PBR)
-
-uniform float oe_sky_exposure;
-uniform vec2 sun_size;
-const vec3 white_point = vec3(1,1,1);
-const vec3 camera_pos = vec3(0,0,0);
-
 in vec3 vp_Normal;
 in vec3 atmos_view_dir;
 in vec3 atmos_light_dir;
-in vec3 atmos_center_to_camera;
 in vec3 atmos_center_to_vert;
-in vec3 atmos_vert_to_light;
 in vec3 atmos_ambient;
+in vec3 atmos_sun_color;
+flat in float atmos_sun_enabled;
 
+in vec3 atmos_center_to_camera;
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
-{    
+{
 #ifdef OE_LIGHTING
-    vec3 N = normalize(vp_Normal);
-	vec3 sky_irradiance;
-	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
-	vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);
-	vec3 atmos_transmittance;
-	vec3 atmos_scatter = GetSkyRadianceToPoint(atmos_center_to_camera, atmos_center_to_vert, 4.0, atmos_light_dir, atmos_transmittance);
-    vec3 ambience = atmos_ambient;
 
-#ifdef OE_USE_PBR
-    atmos_pbr_spec(atmos_view_dir, atmos_vert_to_light, N, ambience, COLOR.rgb);
-#endif
+    vec3 U = atmos_normalize(atmos_center_to_vert, vec3(0, 0, 1));
+    vec3 N = atmos_normalize(vp_Normal, U);
+    if (!gl_FrontFacing) N = -N;
+    vec3 V = atmos_normalize(-atmos_view_dir, N);
+    vec3 L = atmos_normalize(atmos_light_dir, U);
+    vec3 surface = atmos_surfaceRadiance(COLOR.rgb, atmos_center_to_vert, N, V, L,
+        atmos_ambient, atmos_sun_color, atmos_sun_enabled);
 
-    vec3 ambient_floor = COLOR.rgb*ambience;
-
-    // apply radiance and atmospheric effects:
-    COLOR.rgb = COLOR.rgb * radiance * atmos_transmittance + atmos_scatter;
-
-    // apply white point, exposure, and gamma correction:
-	COLOR.rgb = pow(vec3(1,1,1) - exp(-COLOR.rgb / white_point * oe_sky_exposure*1e-5), vec3(1.0 / 2.2));
-
-#ifdef OE_USE_PBR
-    // diffuse contrast + brightness
-    // COLOR.rgb = ((COLOR.rgb - 0.5)*oe_pbr.contrast + 0.5) * oe_pbr.brightness;
-#endif
-
-    // limit to ambient floor:
-    COLOR.rgb = max(COLOR.rgb, ambient_floor);
+    vec3 transmittance;
+    vec3 scatter = GetSkyRadianceToPoint(atmos_center_to_camera, atmos_center_to_vert,
+        0.0, L, transmittance);
+    COLOR.rgb = atmos_finish(surface, transmittance, scatter);
 #endif
 }
-
 )";
 
 
@@ -241,10 +320,11 @@ uniform mat4 osg_ViewMatrix;
 out vec3 atmos_view_dir;
 out vec3 atmos_light_dir;
 out vec3 atmos_center_to_vert;
-out vec3 atmos_vert_to_light;
 out vec3 atmos_transmittance;
 out vec3 atmos_scatter;
 out vec3 atmos_ambient;
+out vec3 atmos_sun_color;
+flat out float atmos_sun_enabled;
 
 uniform float atmos_haze_cutoff;
 uniform float atmos_haze_strength;
@@ -256,14 +336,15 @@ void atmos_eb_ground_render_vert(inout vec4 vertex_view)
     vec3 earth_center = temp.xyz/temp.w;
     atmos_light_dir = normalize(osg_LightSource[0].position.xyz);  // view space
     atmos_ambient = osg_LightSource[0].ambient.rgb;
+    atmos_sun_color = osg_LightSource[0].diffuse.rgb;
+    atmos_sun_enabled = osg_LightSource[0].enabled ? 1.0 : 0.0;
     const vec3 camera_pos = vec3(0,0,0);
     vec3 center_to_camera = (camera_pos - earth_center) * UNIT_LENGTH_METERS_INVERSE;
     atmos_center_to_vert = (vertex_view.xyz - earth_center) * UNIT_LENGTH_METERS_INVERSE;
-    atmos_view_dir = normalize(vertex_view.xyz);
-    atmos_vert_to_light = (osg_LightSource[0].position.xyz - vertex_view.xyz);
+    atmos_view_dir = vertex_view.xyz;
 
 	vec3 transmittance;
-	vec3 in_scatter = GetSkyRadianceToPoint(center_to_camera, atmos_center_to_vert, 4.0, atmos_light_dir, transmittance);
+	vec3 in_scatter = GetSkyRadianceToPoint(center_to_camera, atmos_center_to_vert, 0.0, atmos_light_dir, transmittance);
 
     float vert_unitz = clamp((length(atmos_center_to_vert)-bottom_radius)/(top_radius-bottom_radius), 0, 1);
     float atmos_haze = vert_unitz < atmos_haze_cutoff ? mix(atmos_haze_strength, 1, vert_unitz/atmos_haze_cutoff) : 1.0;
@@ -278,49 +359,30 @@ void atmos_eb_ground_render_vert(inout vec4 vertex_view)
 
 ground_fast_frag= R"(
 #pragma import_defines(OE_LIGHTING)
-#pragma import_defines(OE_USE_PBR)
+in vec3 vp_Normal;
+in vec3 atmos_view_dir;
+in vec3 atmos_light_dir;
+in vec3 atmos_center_to_vert;
+in vec3 atmos_ambient;
+in vec3 atmos_sun_color;
+flat in float atmos_sun_enabled;
+
 in vec3 atmos_transmittance;
 in vec3 atmos_scatter;
-in vec3 atmos_view_dir;
-in vec3 atmos_center_to_vert;
-in vec3 atmos_light_dir;
-in vec3 atmos_vert_to_light;
-in vec3 atmos_ambient;
-in vec3 vp_Normal;
-
-uniform float oe_sky_exposure;
-const vec3 white_point = vec3(1,1,1);
-
 void atmos_eb_ground_render_frag(inout vec4 COLOR)
 {
 #ifdef OE_LIGHTING
-    vec3 N = normalize(vp_Normal);
-	vec3 sky_irradiance;
-	vec3 sun_irradiance = GetSunAndSkyIrradiance(atmos_center_to_vert, N, atmos_light_dir, sky_irradiance);
-    vec3 radiance = (1.0 / PI) * (sun_irradiance + sky_irradiance);
-    vec3 ambience = atmos_ambient;
 
-#ifdef OE_USE_PBR
-    atmos_pbr_spec(atmos_view_dir, atmos_vert_to_light, N, ambience, COLOR.rgb);
+    vec3 U = atmos_normalize(atmos_center_to_vert, vec3(0, 0, 1));
+    vec3 N = atmos_normalize(vp_Normal, U);
+    if (!gl_FrontFacing) N = -N;
+    vec3 V = atmos_normalize(-atmos_view_dir, N);
+    vec3 L = atmos_normalize(atmos_light_dir, U);
+    vec3 surface = atmos_surfaceRadiance(COLOR.rgb, atmos_center_to_vert, N, V, L,
+        atmos_ambient, atmos_sun_color, atmos_sun_enabled);
+
+    COLOR.rgb = atmos_finish(surface, atmos_transmittance, atmos_scatter);
 #endif
-
-    vec3 ambient_floor = COLOR.rgb*ambience;
-
-    // apply radiance and atmospheric effects:
-    COLOR.rgb = COLOR.rgb * radiance * atmos_transmittance + atmos_scatter;
-
-    // apply white point, exposure, and gamma correction:
-	COLOR.rgb = pow(vec3(1,1,1) - exp(-COLOR.rgb / white_point * oe_sky_exposure*1e-5), vec3(1.0 / 2.2));
-
-#ifdef OE_USE_PBR
-    // diffuse contrast + brightness
-    // COLOR.rgb = ((COLOR.rgb - 0.5)*oe_pbr.contrast + 0.5) * oe_pbr.brightness;
-#endif
-
-    // limit to ambient floor:
-    COLOR.rgb = max(COLOR.rgb, ambient_floor);
-
-#endif // OE_LIGHTING
 }
 )";
 
@@ -357,7 +419,7 @@ out vec3 atmos_center_to_camera;
 
 void atmos_eb_sky_render_vert(inout vec4 vertex_view)
 {
-    atmos_view_dir = normalize(vertex_view.xyz);
+    atmos_view_dir = vertex_view.xyz;
     vec4 temp = osg_ViewMatrix * vec4(0,0,0,1);
     vec3 earth_center = temp.xyz/temp.w;
     atmos_light_dir = normalize(osg_LightSource[0].position.xyz);  // view space
@@ -376,14 +438,16 @@ uniform float oe_sky_exposure;
 void atmos_eb_sky_render_frag(inout vec4 OUT_COLOR)
 {
 	vec3 transmittance;
-	vec3 radiance = GetSkyRadiance(atmos_center_to_camera, atmos_view_dir, 0.0, atmos_light_dir, transmittance);
+	vec3 radiance = GetSkyRadiance(atmos_center_to_camera, normalize(atmos_view_dir), 0.0, atmos_light_dir, transmittance);
 
 	// If the view ray intersects the Sun, add the Sun radiance.
     // GW: don't need this.
 	//if (dot(atmos_view_dir, atmos_light_dir) > sun_size.y) 
 	//    radiance = radiance + transmittance * GetSolarRadiance();
 
-	radiance = pow(vec3(1,1,1) - exp(-radiance / white_point * oe_sky_exposure*1e-4), vec3(1.0 / 2.2));
+	vec3 mapped = 1.0 - exp(-max(radiance, vec3(0.0)) * max(oe_sky_exposure, 0.0) * 1e-5);
+    radiance = mix(12.92 * mapped, 1.055 * pow(mapped, vec3(1.0 / 2.4)) - 0.055,
+        greaterThan(mapped, vec3(0.0031308)));
 
 	OUT_COLOR = vec4(radiance, 1.0);
 }

--- a/src/osgEarthImGui/EnvironmentGUI
+++ b/src/osgEarthImGui/EnvironmentGUI
@@ -11,6 +11,10 @@
 #include <osgEarth/Shadowing>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/WindLayer>
+#include <osg/NodeCallback>
+#include <osg/Timer>
+#include <atomic>
+#include <cmath>
 
 namespace
 {
@@ -80,37 +84,96 @@ namespace osgEarth
     class EnvironmentGUI : public ImGuiPanel
     {
     private:
+        // Run on scene updates so recording can continue with the GUI hidden.
+        struct TimeCycle : public osg::NodeCallback
+        {
+            std::atomic<bool> playing{ false };
+            std::atomic<float> hoursPerSecond{ 0.25f };
+
+            void operator()(osg::Node* node, osg::NodeVisitor* nv) override
+            {
+                auto now = osg::Timer::instance()->tick();
+                double elapsed = osg::Timer::instance()->delta_s(_lastTick, now);
+                _lastTick = now;
+                bool running = playing.load();
+
+                if (running && _wasPlaying && elapsed > 0.0)
+                {
+                    // DateTime has whole-second resolution. Retain fractions so
+                    // slow playback does not stall at high frame rates.
+                    _seconds += elapsed * hoursPerSecond.load() * 3600.0;
+                    double wholeSeconds = std::floor(_seconds);
+                    _seconds -= wholeSeconds;
+                    if (wholeSeconds >= 1.0)
+                    {
+                        auto sky = static_cast<SkyNode*>(node);
+                        auto stamp = sky->getDateTime().asTimeStamp();
+                        TimeStamp secondsOfDay = (stamp % 86400 + 86400) % 86400;
+                        TimeStamp advance = static_cast<TimeStamp>(std::fmod(wholeSeconds, 86400.0));
+                        TimeStamp next = (secondsOfDay + advance) % 86400;
+                        // Repeat the selected calendar day, including at midnight.
+                        sky->setDateTime(DateTime(stamp - secondsOfDay + next));
+                    }
+                }
+                if (!running)
+                    _seconds = 0.0;
+                _wasPlaying = running;
+                traverse(node, nv);
+            }
+
+        private:
+            osg::Timer_t _lastTick = osg::Timer::instance()->tick();
+            double _seconds = 0.0;
+            bool _wasPlaying = false;
+        };
+
         osg::observer_ptr<MapNode> _mapNode;
         osg::observer_ptr<SkyNode> _skyNode;
         osg::observer_ptr<ShadowCaster> _shadowCaster;
         osg::observer_ptr<WindLayer> _windLayer;
+        osg::ref_ptr<TimeCycle> _timeCycle;
+        float _timeCycleSpeed = 0.25f;
         bool _showDetails = false;
-        float _hour;
-        int _day, _month, _year;
         float _exposure = 3.3f;
         float _contrast = 1.0f;
         float _ambient = 0.033f;
         float _max_ambient_intensity = 0.15f;
+        float _environment_strength = 1.0f;
+        float _ground_reflectance = 0.15f;
         bool _first = true;
         bool _shadows = false;
         float _haze_cutoff = 0.0f, _haze_strength = 16.0f;
-        float _shadow_darkness = 0.5f, _shadow_blur = 0.001f;
+        float _shadow_darkness = 0.0f, _shadow_blur = 0.001f;
         float _wind_power = 1.0f;
 
     public:
-        EnvironmentGUI() : ImGuiPanel("Sky")
+        EnvironmentGUI() : ImGuiPanel("Sky") { }
+
+        ~EnvironmentGUI() override
         {
-            DateTime now;
-            _hour = now.hours(), _day = now.day(), _month = now.month(), _year = now.year();
+            if (_timeCycle.valid())
+            {
+                _timeCycle->playing = false;
+                osg::ref_ptr<SkyNode> sky;
+                if (_skyNode.lock(sky))
+                    sky->removeUpdateCallback(_timeCycle.get());
+            }
         }
 
         void load(const Config& conf) override
         {
             conf.get("ShowDetails", _showDetails);
+            conf.get("TimeCycleSpeed", _timeCycleSpeed);
+            _timeCycleSpeed = std::isfinite(_timeCycleSpeed) ?
+                osg::clampBetween(_timeCycleSpeed, 0.01f, 24.0f) : 0.25f;
+            if (_timeCycle.valid())
+                _timeCycle->hoursPerSecond = _timeCycleSpeed;
             conf.get("Exposure", _exposure);
             conf.get("Contrast", _contrast);
             conf.get("Ambient", _ambient);
             conf.get("AmbientMax", _max_ambient_intensity);
+            conf.get("SkyEnvironment", _environment_strength);
+            conf.get("GroundReflectance", _ground_reflectance);
             conf.get("HazeCutoff", _haze_cutoff);
             conf.get("HazeStrength", _haze_strength);
             conf.get("WindPower", _wind_power);
@@ -118,10 +181,13 @@ namespace osgEarth
         void save(Config& conf) override
         {
             conf.set("ShowDetails", _showDetails);
+            conf.set("TimeCycleSpeed", _timeCycleSpeed);
             conf.set("Exposure", _exposure);
             conf.set("Contrast", _contrast);
             conf.set("Ambient", _ambient);
             conf.set("AmbientMax", _max_ambient_intensity);
+            conf.set("SkyEnvironment", _environment_strength);
+            conf.set("GroundReflectance", _ground_reflectance);
             conf.set("HazeCutoff", _haze_cutoff);
             conf.set("HazeStrength", _haze_strength);
             conf.set("WindPower", _wind_power);
@@ -150,6 +216,13 @@ namespace osgEarth
                     return;
                 }
 
+                if (!_timeCycle.valid())
+                {
+                    _timeCycle = new TimeCycle;
+                    _timeCycle->hoursPerSecond = _timeCycleSpeed;
+                    _skyNode->addUpdateCallback(_timeCycle.get());
+                }
+
                 if (_first)
                 {
                     findNode(_shadowCaster, ri);
@@ -158,9 +231,8 @@ namespace osgEarth
 
                     findLayer(_windLayer, ri);
 
-                    _skyNode->setDateTime(DateTime(_year, _month, _day, _hour));
-
-                    // so we can visualize tiume-series layers.
+                    // Preserve the scene's selected date/time when opening the
+                    // panel; simulation time also drives time-series layers.
                     _skyNode->setSimulationTimeTracksDateTime(true);
                 }
 
@@ -179,6 +251,7 @@ namespace osgEarth
 
                 ImGui::SameLine();
                 if (ImGui::Button("Now")) {
+                    _timeCycle->playing = false;
                     _skyNode->setDateTime(DateTime());
                     dirtySettings();
                 }
@@ -194,30 +267,76 @@ namespace osgEarth
                     auto year = mark.year();
                     auto hour = mark.hours();
 
-                    if (ImGuiLTable::SliderDouble("Hour (UTC)", &hour, 0.0f, 24.0f))
-                        _hour = hour, dirtySettings();
+                    bool dateChanged = ImGuiLTable::SliderDouble("Hour (UTC)", &hour, 0.0f, 24.0f);
+
+                    bool cycleTime = _timeCycle->playing.load();
+                    if (ImGuiLTable::Checkbox("Cycle time", &cycleTime))
+                        _timeCycle->playing = cycleTime;
+                    if (ImGui::IsItemHovered())
+                        ImGui::SetTooltip("Repeat this day automatically. Continues with the Sky panel or GUI hidden.");
+                    if (ImGuiLTable::SliderFloat("Speed (hours/sec)", &_timeCycleSpeed, 0.01f, 24.0f,
+                        "%.2f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_AlwaysClamp))
+                    {
+                        _timeCycle->hoursPerSecond = _timeCycleSpeed;
+                        dirtySettings();
+                    }
+                    if (ImGui::IsItemHovered())
+                        ImGui::SetTooltip("Simulated hours per real second. Ctrl-click to enter an exact speed.");
+                    ImGuiLTable::Text("Day loop", "%.1f seconds", 24.0f / _timeCycleSpeed);
 
                     if (_showDetails)
                     {
-                        if (ImGuiLTable::SliderInt("Day", &day, 1, 31))
-                            _day = day, dirtySettings();
-                        if (ImGuiLTable::SliderInt("Month", &month, 1, 12))
-                            _month = month, dirtySettings();
-                        if (ImGuiLTable::SliderInt("Year", &year, 1970, 2061))
-                            _year = year, dirtySettings();
+                        dateChanged |= ImGuiLTable::SliderInt("Day", &day, 1, 31);
+                        dateChanged |= ImGuiLTable::SliderInt("Month", &month, 1, 12);
+                        dateChanged |= ImGuiLTable::SliderInt("Year", &year, 1970, 2061);
                     }
-                    _skyNode->setDateTime(DateTime(year, month, day, hour));
+                    if (dateChanged)
+                    {
+                        _timeCycle->playing = false;
+                        _skyNode->setDateTime(DateTime(year, month, day, hour));
+                        dirtySettings();
+                    }
 
                     if (lighting)
                     {
+                        auto skyStateSet = _skyNode->getOrCreateStateSet();
+                        auto environmentStrength = skyStateSet->getUniform("oe_sky_iblStrength");
+                        auto environmentDefine = skyStateSet->getDefinePair("OE_SKY_ENVIRONMENT");
+                        bool environmentActive = environmentStrength && environmentDefine &&
+                            (environmentDefine->second & osg::StateAttribute::ON) != 0;
+
                         if (ImGuiLTable::SliderFloat("Exposure", &_exposure, 1.0f, 10.0f)) dirtySettings();
                         _skyNode->getOrCreateStateSet()->getOrCreateUniform("oe_sky_exposure", osg::Uniform::FLOAT)->set(_exposure);
 
                         if (ImGuiLTable::SliderFloat("Ambient min", &_ambient, 0.0f, 1.0f)) dirtySettings();
                         _skyNode->getSunLight()->setAmbient(osg::Vec4(_ambient, _ambient, _ambient, 1.0f));
 
-                        if (ImGuiLTable::SliderFloat("Ambient max", &_max_ambient_intensity, 0.0f, 1.0f)) dirtySettings();
-                        _skyNode->getOrCreateStateSet()->getOrCreateUniform("oe_sky_maxAmbientIntensity", osg::Uniform::FLOAT)->set(_max_ambient_intensity);
+                        auto ambientMaximum = skyStateSet->getUniform("oe_sky_maxAmbientIntensity");
+                        if (ambientMaximum)
+                        {
+                            if (ImGuiLTable::SliderFloat("Ambient max",
+                                &_max_ambient_intensity, 0.0f, 1.0f)) dirtySettings();
+                            if (ImGui::IsItemHovered())
+                                ImGui::SetTooltip("Daytime ambient fill. Fades out as Sky environment approaches 1.");
+                            ambientMaximum->set(_max_ambient_intensity);
+                        }
+
+                        if (environmentActive)
+                        {
+                            if (ImGuiLTable::SliderFloat("Sky environment", &_environment_strength, 0.0f, 1.0f)) dirtySettings();
+                            if (ImGui::IsItemHovered())
+                                ImGui::SetTooltip("Controls sky fill and reflections. Ambient min remains separate.");
+                            environmentStrength->set(_environment_strength);
+
+                            auto groundReflectance = skyStateSet->getUniform("oe_sky_groundReflectance");
+                            if (groundReflectance)
+                            {
+                                if (ImGuiLTable::SliderFloat("Ground reflectance", &_ground_reflectance, 0.0f, 1.0f)) dirtySettings();
+                                if (ImGui::IsItemHovered())
+                                    ImGui::SetTooltip("Assumed linear reflectance of surrounding ground for indirect light.");
+                                groundReflectance->set(_ground_reflectance);
+                            }
+                        }
 
                         auto diffuse_color = _skyNode->getSunLight()->getDiffuse();
                         if (ImGuiLTable::ColorEdit3("Diffuse color", &diffuse_color[0], ImGuiColorEditFlags_Float)) {
@@ -265,7 +384,7 @@ namespace osgEarth
 
                         if (_shadows)
                         {
-                            if (ImGuiLTable::SliderFloat("Shadow darkness", &_shadow_darkness, 0.0f, 1.0f))
+                            if (ImGuiLTable::SliderFloat("Sunlight in shadow", &_shadow_darkness, 0.0f, 1.0f))
                                 stateset(ri)->addUniform(new osg::Uniform("oe_shadow_color", _shadow_darkness), 0x7);
 
                             if (ImGuiLTable::SliderFloat("Shadow blur", &_shadow_blur, 0.0f, 0.002f))

--- a/src/osgEarthImGui/EnvironmentGUI
+++ b/src/osgEarthImGui/EnvironmentGUI
@@ -87,10 +87,10 @@ namespace osgEarth
         bool _showDetails = false;
         float _hour;
         int _day, _month, _year;
-        float _exposure = 3.5f;
+        float _exposure = 3.3f;
         float _contrast = 1.0f;
         float _ambient = 0.033f;
-        float _max_ambient_intensity = 0.75;
+        float _max_ambient_intensity = 0.15f;
         bool _first = true;
         bool _shadows = false;
         float _haze_cutoff = 0.0f, _haze_strength = 16.0f;
@@ -110,6 +110,7 @@ namespace osgEarth
             conf.get("Exposure", _exposure);
             conf.get("Contrast", _contrast);
             conf.get("Ambient", _ambient);
+            conf.get("AmbientMax", _max_ambient_intensity);
             conf.get("HazeCutoff", _haze_cutoff);
             conf.get("HazeStrength", _haze_strength);
             conf.get("WindPower", _wind_power);
@@ -120,6 +121,7 @@ namespace osgEarth
             conf.set("Exposure", _exposure);
             conf.set("Contrast", _contrast);
             conf.set("Ambient", _ambient);
+            conf.set("AmbientMax", _max_ambient_intensity);
             conf.set("HazeCutoff", _haze_cutoff);
             conf.set("HazeStrength", _haze_strength);
             conf.set("WindPower", _wind_power);

--- a/src/osgEarthImGui/ImGuiApp
+++ b/src/osgEarthImGui/ImGuiApp
@@ -99,7 +99,10 @@ namespace osgEarth
             if (menu.empty())
                 add(panel);
             else
+            {
+                panel->_dirtySettings = &_dirtySettings;
                 _menu[menu].push_back(GUIPtr(panel));
+            }
         }
 
         void addSeparator(const std::string& menu)

--- a/src/osgEarthImGui/ImGuiPanel
+++ b/src/osgEarthImGui/ImGuiPanel
@@ -31,6 +31,8 @@ namespace osgEarth
     class ImGuiPanel // no export
     {
     public:
+        virtual ~ImGuiPanel() = default;
+
         void setVisible(bool value) {
             _visible = value;
             dirtySettings();


### PR DESCRIPTION
Sky lighting could wash out surface detail and turn shaded faces nearly black, while previewing a day/night cycle required manually dragging the time slider. This adds material-aware sky lighting, keeps indirect light in shadows, and adds automatic time playback to the Sky panel.

This PR targets `master` and includes the normal-lighting fixes from #3004 as a prerequisite, so it can be reviewed and merged independently. It contains only lighting/shadow changes and the ImGui support required for the Sky controls.

## Lighting and shadows

- Use surface normals for direct sunlight, normalize fragment normals, and lower the ambient defaults that previously overwhelmed directional lighting.
- Have shadow sampling output direct-sun visibility. Built-in Phong, O'Neil, and Bruneton lighting apply it to sunlight while preserving indirect lighting and material response. Bound the slope bias and select the first containing shadow cascade.
- Add a procedural sky/ground environment probe to default/medium SimpleSky, with spherical-harmonic diffuse irradiance, GGX-prefiltered reflections, and a BRDF lookup. The probe follows the sun and local up direction and falls back when texture units are unavailable.
- For `--sky-high` and `--sky-best`, use Bruneton's atmospheric radiance for roughness-dependent reflections and add approximate ground bounce. Respect metallic, roughness, normals, normal maps, and material AO; apply AO to indirect light rather than direct sunlight.
- Combine surface light, atmospheric transmission, and scattering in linear space before tone mapping and sRGB encoding. Align sky and surface exposure, correct directional sun/view calculations, filter small specular highlights, and use the solar angular radius when approximating direct highlights. High uses 8 reflection samples; best uses 16 and computes aerial perspective per fragment.

## Sky panel

- Add **Sky environment** and, for Bruneton, **Ground reflectance** controls. Ambient min remains independent. **Ambient max** retains a plain label and explains that its contribution fades out as Sky environment approaches 1; hide it in high/best where it is unused.
- Add **Cycle time**, **Speed (hours/sec)**, and a **Day loop** duration readout. The default 0.25 hours/sec gives a 96-second day. Playback repeats the selected calendar day, continues when the panel/UI is hidden, and pauses when the user scrubs the time, edits the date, or clicks Now.
- Drive playback from elapsed real time in a scene update callback, retaining fractional simulated seconds so slow playback does not stall. Preserve the scene's date/time when opening the panel. Save speed while starting playback paused on application launch.
- Connect panels in named menus to the existing settings-dirty mechanism so changed settings are saved. Add a virtual panel destructor so Sky can detach its update callback when destroyed.

## Validation

- Built and installed the implementation with the repository's `build.bat` in the development checkout.
- Development-checkout unit suite passed: **3,079 assertions in 76 test cases**.
- Visually checked Prestige at Pittsburgh and Morgantown, including high/best quality, shadows, environment lighting disabled, low sun, and night. Checked the environment slider with ambient set to zero.
- Checked playback rate, midnight wrapping without advancing the date, pause on scrubbing, continued playback with Sky closed, and persistence of the speed setting. Full-GUI hiding uses the same independent update callback; the keyboard toggle was not successfully exercised by UI automation.
- Applied the changes cleanly to the latest `master`, verified the changed-file scope and source equivalence, and passed `git diff --check`. The isolated PR worktree has not had a separate clean build.

## Limits

The environment represents the sky and approximate ground bounce, not reflections of surrounding buildings or local occlusion of skylight. Material AO supplies local indirect occlusion. High/best add fragment-shader work; no performance improvement is claimed. Custom lighting shaders must consume `oe_shadow_visibility` under `OE_SHADOWING` to apply shadows to their direct sun contribution.
